### PR TITLE
Add game reset/restart endpoint

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -27,6 +27,11 @@ func main() {
 			srv.HandleBotAction(w, r)
 			return
 		}
+		// Check if this is a reset endpoint: /api/rooms/{roomId}/reset
+		if strings.HasSuffix(r.URL.Path, "/reset") {
+			srv.HandleResetGame(w, r)
+			return
+		}
 		// Otherwise, handle as room state endpoint: /api/rooms/{roomId}/state
 		srv.HandleGetRoomState(w, r)
 	})

--- a/backend/pkg/server/game_objects/player_game_object.go
+++ b/backend/pkg/server/game_objects/player_game_object.go
@@ -553,6 +553,54 @@ func (p *PlayerGameObject) doRespawn() {
 	p.respawnMutex.Unlock()
 }
 
+// CancelRespawnTimer cancels any pending respawn timer
+func (p *PlayerGameObject) CancelRespawnTimer() {
+	p.respawnMutex.Lock()
+	defer p.respawnMutex.Unlock()
+	if p.respawnTimer != nil {
+		p.respawnTimer.Stop()
+		p.respawnTimer = nil
+	}
+	p.respawning = false
+}
+
+// Reset resets the player to initial state at a random respawn location
+// This cancels any pending respawn timer and resets all player state
+func (p *PlayerGameObject) Reset() {
+	// Cancel any pending respawn timer
+	p.CancelRespawnTimer()
+
+	// Reset position to respawn location
+	respawnX, respawnY := p.getRespawnLocation()
+	p.SetState(constants.StateX, respawnX)
+	p.SetState(constants.StateY, respawnY)
+
+	// Reset velocity
+	p.SetState(constants.StateDx, 0.0)
+	p.SetState(constants.StateDy, 0.0)
+
+	// Reset direction (pointing downward)
+	p.SetState(constants.StateDir, math.Pi*3/2)
+
+	// Reset health
+	p.SetState(constants.StateHealth, constants.PlayerStartingHealth)
+
+	// Reset dead state
+	p.SetState(constants.StateDead, false)
+
+	// Reset shooting state
+	p.SetState(constants.StateShooting, false)
+
+	// Reset jump count
+	p.SetState(constants.StateJumpCount, 0)
+
+	// Reset arrow count
+	p.SetState(constants.StateArrowCount, constants.PlayerStartingArrows)
+
+	// Update last location update time
+	p.SetState(constants.StateLastLocUpdateTime, time.Now())
+}
+
 // GetProperty returns the game object's properties
 func (p *PlayerGameObject) GetProperty(key GameObjectProperty) (interface{}, bool) {
 	switch key {

--- a/backend/pkg/server/object_manager.go
+++ b/backend/pkg/server/object_manager.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"errors"
+	"go-ws-server/pkg/server/constants"
 	"go-ws-server/pkg/server/game_maps"
 	"go-ws-server/pkg/server/game_objects"
 	"log"
@@ -127,6 +128,23 @@ func (m *GameObjectManager) GetAllStates() map[string]map[string]interface{} {
 		}
 	}
 	return allStates
+}
+
+// ClearNonPlayerObjects removes all non-player objects (arrows, bullets, etc.) from the manager
+// This is used during game reset to clear the arena while keeping players
+func (m *GameObjectManager) ClearNonPlayerObjects() {
+	m.Mutex.Lock()
+	defer m.Mutex.Unlock()
+
+	for id, obj := range m.Objects {
+		if obj == nil {
+			continue
+		}
+		// Keep player objects, remove everything else (arrows, bullets, etc.)
+		if obj.GetObjectType() != constants.ObjectTypePlayer {
+			m.Objects[id] = nil
+		}
+	}
 }
 
 func (m *GameObjectManager) HandleEvent(e *game_objects.GameEvent) (*GameObjectManagerHandleEventResult, error) {


### PR DESCRIPTION
Closes #23

## Summary

- Implements `POST /api/rooms/{roomId}/reset` REST API endpoint for resetting game state between ML training episodes
- Adds `Reset()` method to `GameRoom` that resets all players to initial state and clears non-player objects (arrows)
- Adds `Reset()` and `CancelRespawnTimer()` methods to `PlayerGameObject` for resetting individual player state
- Adds `ClearNonPlayerObjects()` method to `ObjectManager` to remove arrows while preserving players and map blocks
- Broadcasts full game state update to connected WebSocket clients after reset

## Test plan

- [x] Unit tests for `GameRoom.Reset()` verify player states are reset and kill count/start time are reset
- [x] Unit tests verify non-player objects (arrows) are cleared while players remain
- [x] Unit tests verify spectators remain connected after reset
- [x] Integration tests for `HandleResetGame` HTTP handler cover:
  - Valid requests with `X-Player-Token` header and `Authorization: Bearer` token
  - Missing/invalid player token (401/403 responses)
  - Room not found (404 response)
  - Invalid URL format (400 response)
  - HTTP method validation (405 for non-POST)
  - CORS preflight handling
  - Player state verification after reset
- [x] All existing tests pass