### PR TITLE
Define Discrete Action Space for ML Bot Training

### DIFF
--- a/bot2/src/bot/actions.py
+++ b/bot2/src/bot/actions.py
@@ -24,12 +24,8 @@ from __future__ import annotations
 
 import math
 from enum import IntEnum
-from typing import TYPE_CHECKING
 
-from bot.models import BotAction
-
-if TYPE_CHECKING:
-    from bot.client import GameClient
+from bot.client import GameClient
 
 
 class Action(IntEnum):
@@ -258,26 +254,7 @@ async def _send_direction(client: GameClient, direction: float) -> None:
         client: The GameClient instance.
         direction: Direction in radians.
     """
-    # Import here to avoid circular imports
-    from bot.client.game_client import ClientMode, GameClientError
-
-    if client.mode == ClientMode.WEBSOCKET:
-        # WebSocket mode: send ClientState message
-        if client._websocket is None:
-            raise GameClientError("WebSocket not connected")
-        import json
-
-        message = {"type": "ClientState", "payload": {"direction": direction}}
-        await client._websocket.send(json.dumps(message))
-    else:
-        # REST mode: submit direction action
-        if client.room_id is None or client.player_id is None:
-            raise GameClientError("Not connected to a game")
-        await client._http_client.submit_action(
-            room_id=client.room_id,
-            player_id=client.player_id,
-            actions=[BotAction(type="direction", direction=direction)],
-        )
+    await client.send_direction(direction)
 
 
 def action_to_string(action: Action | int) -> str:

--- a/bot2/src/bot/client/game_client.py
+++ b/bot2/src/bot/client/game_client.py
@@ -366,6 +366,19 @@ class GameClient:
                 )
             )
 
+    async def send_direction(self, direction: float) -> None:
+        """Send aim direction update.
+
+        Args:
+            direction: Direction in radians (0 to 2π).
+        """
+        if self.mode == ClientMode.WEBSOCKET:
+            await self._send_ws_direction(direction)
+        else:
+            await self._send_rest_action(
+                BotAction(type="direction", direction=direction)
+            )
+
     async def _send_ws_keyboard(self, key: str, pressed: bool) -> None:
         """Send keyboard input via WebSocket."""
         if self._websocket is None:
@@ -396,6 +409,18 @@ class GameClient:
             "type": "Click",
             "payload": {"x": x, "y": y, "button": button, "isDown": pressed},
         }
+        await self._websocket.send(json.dumps(message))
+
+    async def _send_ws_direction(self, direction: float) -> None:
+        """Send direction update via WebSocket.
+
+        Args:
+            direction: Direction in radians.
+        """
+        if self._websocket is None:
+            raise GameClientError("WebSocket not connected")
+
+        message = {"type": "ClientState", "payload": {"direction": direction}}
         await self._websocket.send(json.dumps(message))
 
     async def _send_rest_action(self, action: BotAction) -> None:


### PR DESCRIPTION
**Closes:** #30
**Parent Task:** TASK-P003 (Observation & Action Space)
**Epic:** #14 (ML Bot Training)

## Summary

This PR implements the discrete action space for RL agents in the ML bot training system. The action space defines 27 discrete actions that map agent decisions to game inputs, following the requirement that key press and release are treated as separate actions.

### Key Changes

- **New `bot2/src/bot/actions.py` module** - Contains the `Action` enum with all 27 discrete actions, helper functions for action conversion, and the `execute_action()` function for translating actions to GameClient calls
- **Extended `GameClient` with `send_direction()` method** - Added direction update support for aim actions via both WebSocket and REST modes
- **Comprehensive test suite** - 415 lines of tests covering all action enum values, conversion functions, category checks, and action execution with mocked GameClient

## Action Space Design

| Category | Actions | IDs | Description |
|----------|---------|-----|-------------|
| Movement | 8 | 0-7 | Press/release for A, D, W, S keys |
| Aim Direction | 16 | 8-23 | 16 buckets covering 0 to 2π radians (22.5° per bucket) |
| Shooting | 2 | 24-25 | Mouse button press/release |
| No-Op | 1 | 26 | Do nothing |

**Total: 27 discrete actions**

## Implementation Details

### Action Enum
All actions are defined as an `IntEnum` for direct compatibility with Gymnasium's `Discrete` action space:
```python
action_space = gym.spaces.Discrete(ACTION_SPACE_SIZE)  # 27 actions
```

### Helper Functions
- `aim_action_to_radians()` - Convert aim action to radians
- `radians_to_aim_action()` - Convert radians to nearest aim action
- `is_aim_action()`, `is_movement_action()`, `is_shoot_action()` - Category checks
- `execute_action()` - Async function to execute actions through GameClient

### GameClient Extension
Added `send_direction()` method supporting both modes:
- WebSocket: Sends `ClientState` message with direction payload
- REST: Sends `BotAction` with direction field

## Test Plan

- [x] Action enum defines all 27 discrete actions with correct values
- [x] Action values form a contiguous range from 0-26
- [x] `aim_action_to_radians()` correctly converts all 16 aim actions
- [x] `radians_to_aim_action()` handles negative and large radians (normalization)
- [x] Roundtrip conversion (action → radians → action) is lossless
- [x] Category check functions correctly identify action types
- [x] `execute_action()` sends correct keyboard/mouse/direction inputs
- [x] NO_OP action does nothing
- [x] Gymnasium Discrete space integration works correctly
