### PR TITLE
Reward Function for TowerFall RL Environment

### DIFF
--- a/bot2/src/bot/gym/__init__.py
+++ b/bot2/src/bot/gym/__init__.py
@@ -4,15 +4,23 @@ This module provides a gymnasium environment for training RL agents
 to play TowerFall through the go-towerfall game server.
 
 Usage:
-    from bot.gym import TowerfallEnv
+    from bot.gym import TowerfallEnv, RewardConfig
 
-    # Direct instantiation
+    # Direct instantiation with default rewards
     env = TowerfallEnv(
         http_url="http://localhost:4000",
         player_name="TrainingBot",
         map_type="arena1",
         tick_rate_multiplier=10.0,
     )
+
+    # Custom reward configuration
+    reward_config = RewardConfig(
+        kill_reward=2.0,
+        death_penalty=-1.5,
+        timestep_penalty=-0.002,
+    )
+    env = TowerfallEnv(reward_config=reward_config)
 
     # Or via gymnasium registry
     import gymnasium as gym
@@ -28,9 +36,10 @@ Usage:
     env.close()
 """
 
+from bot.gym.reward import RewardConfig, RewardFunction, StandardRewardFunction
 from bot.gym.towerfall_env import TowerfallEnv
 
-__all__ = ["TowerfallEnv"]
+__all__ = ["TowerfallEnv", "RewardConfig", "RewardFunction", "StandardRewardFunction"]
 
 # Register with gymnasium
 from gymnasium.envs.registration import register

--- a/bot2/src/bot/gym/reward.py
+++ b/bot2/src/bot/gym/reward.py
@@ -1,0 +1,178 @@
+"""Reward function implementation for TowerFall RL training.
+
+This module provides configurable reward functions for training RL agents.
+The reward function incentivizes aggressive play (kills) while penalizing
+deaths and encouraging efficient gameplay through time penalties.
+
+Design rationale:
+- Kill reward (+1.0): Positive reinforcement for eliminating opponents
+- Death penalty (-1.0): Symmetric penalty to optimize kill/death ratio
+- Timestep penalty (-0.001): Small negative to discourage passive play
+
+Usage:
+    from bot.gym.reward import RewardConfig, StandardRewardFunction
+
+    # Default configuration
+    reward_fn = StandardRewardFunction()
+
+    # Custom configuration
+    config = RewardConfig(kill_reward=2.0, timestep_penalty=-0.002)
+    reward_fn = StandardRewardFunction(config)
+
+    # In training loop
+    reward_fn.reset(initial_stats)
+    reward = reward_fn.calculate(current_stats)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from bot.models import PlayerStatsDTO
+
+
+@dataclass
+class RewardConfig:
+    """Configuration for reward function parameters.
+
+    Attributes:
+        kill_reward: Reward for each kill. Default: +1.0
+        death_penalty: Penalty for each death (negative value). Default: -1.0
+        timestep_penalty: Small penalty per step to encourage efficiency. Default: -0.001
+    """
+
+    kill_reward: float = 1.0
+    death_penalty: float = -1.0
+    timestep_penalty: float = -0.001
+
+
+class RewardFunction(Protocol):
+    """Protocol for reward function implementations.
+
+    This protocol allows for different reward function strategies to be
+    used interchangeably in the TowerfallEnv.
+    """
+
+    def reset(self, initial_stats: PlayerStatsDTO | None) -> None:
+        """Reset tracking for new episode.
+
+        Args:
+            initial_stats: Initial player statistics, or None if unavailable.
+        """
+        ...
+
+    def calculate(self, current_stats: PlayerStatsDTO | None) -> float:
+        """Calculate reward based on current statistics.
+
+        Args:
+            current_stats: Current player statistics, or None if unavailable.
+
+        Returns:
+            Reward value for this step.
+        """
+        ...
+
+
+class StandardRewardFunction:
+    """Standard reward function for TowerFall training.
+
+    Calculates rewards based on:
+    - Kill deltas: +kill_reward for each new kill
+    - Death deltas: +death_penalty (negative) for each new death
+    - Timestep penalty: Small negative reward each step
+
+    The function tracks previous kill/death counts to calculate deltas,
+    ensuring rewards reflect changes rather than absolute values.
+
+    Example:
+        >>> config = RewardConfig(kill_reward=1.0, death_penalty=-1.0)
+        >>> reward_fn = StandardRewardFunction(config)
+        >>> reward_fn.reset(PlayerStatsDTO(player_id="p1", player_name="Bot", kills=0, deaths=0))
+        >>> # After getting a kill
+        >>> reward = reward_fn.calculate(PlayerStatsDTO(player_id="p1", player_name="Bot", kills=1, deaths=0))
+        >>> # reward ≈ 0.999 (1.0 for kill - 0.001 timestep penalty)
+    """
+
+    def __init__(self, config: RewardConfig | None = None):
+        """Initialize the reward function.
+
+        Args:
+            config: Optional reward configuration. Uses defaults if not provided.
+        """
+        self.config = config or RewardConfig()
+        self._prev_kills: int = 0
+        self._prev_deaths: int = 0
+
+    def reset(self, initial_stats: PlayerStatsDTO | None) -> None:
+        """Reset tracking for new episode.
+
+        Args:
+            initial_stats: Initial player statistics, or None if unavailable.
+                          If None, previous counts are reset to 0.
+        """
+        if initial_stats is not None:
+            self._prev_kills = initial_stats.kills
+            self._prev_deaths = initial_stats.deaths
+        else:
+            self._prev_kills = 0
+            self._prev_deaths = 0
+
+    def calculate(self, current_stats: PlayerStatsDTO | None) -> float:
+        """Calculate reward based on current statistics.
+
+        The reward is computed as:
+            reward = (kill_delta * kill_reward) +
+                     (death_delta * death_penalty) +
+                     timestep_penalty
+
+        Args:
+            current_stats: Current player statistics, or None if unavailable.
+
+        Returns:
+            Reward value for this step. If stats are unavailable,
+            returns only the timestep penalty.
+        """
+        reward = 0.0
+
+        if current_stats is not None:
+            current_kills = current_stats.kills
+            current_deaths = current_stats.deaths
+
+            # Reward for kills (delta-based)
+            kill_diff = current_kills - self._prev_kills
+            reward += kill_diff * self.config.kill_reward
+
+            # Penalty for deaths (delta-based)
+            death_diff = current_deaths - self._prev_deaths
+            reward += death_diff * self.config.death_penalty
+
+            # Update tracking for next step
+            self._prev_kills = current_kills
+            self._prev_deaths = current_deaths
+
+        # Always apply timestep penalty
+        reward += self.config.timestep_penalty
+
+        return reward
+
+    def get_config(self) -> RewardConfig:
+        """Get the current reward configuration.
+
+        Returns:
+            The RewardConfig instance used by this function.
+        """
+        return self.config
+
+    def get_episode_stats(self) -> dict[str, Any]:
+        """Get current episode tracking statistics.
+
+        Useful for debugging and logging reward calculations.
+
+        Returns:
+            Dictionary with current tracked kills and deaths.
+        """
+        return {
+            "prev_kills": self._prev_kills,
+            "prev_deaths": self._prev_deaths,
+        }

--- a/bot2/tests/test_env.py
+++ b/bot2/tests/test_env.py
@@ -465,8 +465,8 @@ class TestTowerfallEnvReward:
         env = TowerfallEnv()
         env._client = MagicMock()
         env._client.player_id = "player-456"
-        env._prev_kills = 0
-        env._prev_deaths = 0
+        # Reset reward function to initial state
+        env._reward_fn.reset(None)
 
         player_state = make_player_state_dict()
         game_state = GameState(
@@ -482,15 +482,15 @@ class TestTowerfallEnvReward:
 
         # Should be +1.0 for kill, -0.001 for step
         assert reward == pytest.approx(1.0 - 0.001, abs=0.0001)
-        assert env._prev_kills == 1
+        assert env._reward_fn.get_episode_stats()["prev_kills"] == 1
 
     def test_reward_for_death(self) -> None:
         """Test reward decreases for deaths."""
         env = TowerfallEnv()
         env._client = MagicMock()
         env._client.player_id = "player-456"
-        env._prev_kills = 0
-        env._prev_deaths = 0
+        # Reset reward function to initial state
+        env._reward_fn.reset(None)
 
         player_state = make_player_state_dict()
         game_state = GameState(
@@ -506,15 +506,15 @@ class TestTowerfallEnvReward:
 
         # Should be -1.0 for death, -0.001 for step
         assert reward == pytest.approx(-1.0 - 0.001, abs=0.0001)
-        assert env._prev_deaths == 1
+        assert env._reward_fn.get_episode_stats()["prev_deaths"] == 1
 
     def test_reward_step_penalty(self) -> None:
         """Test small negative reward per step."""
         env = TowerfallEnv()
         env._client = MagicMock()
         env._client.player_id = "player-456"
-        env._prev_kills = 0
-        env._prev_deaths = 0
+        # Reset reward function to initial state
+        env._reward_fn.reset(None)
 
         player_state = make_player_state_dict()
         game_state = GameState(
@@ -536,8 +536,8 @@ class TestTowerfallEnvReward:
         env = TowerfallEnv()
         env._client = MagicMock()
         env._client.player_id = "player-456"
-        env._prev_kills = 5
-        env._prev_deaths = 2
+        # Initialize reward function with previous state
+        env._reward_fn.reset(make_player_stats(kills=5, deaths=2))
 
         player_state = make_player_state_dict()
         game_state = GameState(

--- a/bot2/tests/test_reward.py
+++ b/bot2/tests/test_reward.py
@@ -1,0 +1,438 @@
+"""Unit tests for the reward function module.
+
+Tests cover:
+- RewardConfig dataclass initialization and defaults
+- StandardRewardFunction initialization and configuration
+- Reset method behavior with and without initial stats
+- Reward calculation for kills, deaths, and timestep penalty
+- Delta-based reward tracking across multiple steps
+- Edge cases (multiple kills/deaths in one step, None stats)
+"""
+
+from typing import Any
+
+import pytest
+
+from bot.gym.reward import RewardConfig, StandardRewardFunction
+from bot.models import PlayerStatsDTO
+
+
+def make_player_stats(**overrides: Any) -> PlayerStatsDTO:
+    """Create a PlayerStatsDTO for testing."""
+    data: dict[str, Any] = {
+        "playerId": "player-456",
+        "playerName": "TestPlayer",
+        "kills": 0,
+        "deaths": 0,
+    }
+    data.update(overrides)
+    return PlayerStatsDTO.model_validate(data)
+
+
+class TestRewardConfig:
+    """Tests for RewardConfig dataclass."""
+
+    def test_default_values(self) -> None:
+        """Test RewardConfig has correct default values."""
+        config = RewardConfig()
+
+        assert config.kill_reward == 1.0
+        assert config.death_penalty == -1.0
+        assert config.timestep_penalty == -0.001
+
+    def test_custom_values(self) -> None:
+        """Test RewardConfig accepts custom values."""
+        config = RewardConfig(
+            kill_reward=2.0,
+            death_penalty=-0.5,
+            timestep_penalty=-0.01,
+        )
+
+        assert config.kill_reward == 2.0
+        assert config.death_penalty == -0.5
+        assert config.timestep_penalty == -0.01
+
+    def test_zero_values(self) -> None:
+        """Test RewardConfig accepts zero values."""
+        config = RewardConfig(
+            kill_reward=0.0,
+            death_penalty=0.0,
+            timestep_penalty=0.0,
+        )
+
+        assert config.kill_reward == 0.0
+        assert config.death_penalty == 0.0
+        assert config.timestep_penalty == 0.0
+
+    def test_positive_death_penalty(self) -> None:
+        """Test RewardConfig allows positive death_penalty (for experimentation)."""
+        config = RewardConfig(death_penalty=0.5)
+
+        assert config.death_penalty == 0.5
+
+
+class TestStandardRewardFunctionInit:
+    """Tests for StandardRewardFunction initialization."""
+
+    def test_default_config(self) -> None:
+        """Test initialization with default configuration."""
+        reward_fn = StandardRewardFunction()
+
+        assert reward_fn.config.kill_reward == 1.0
+        assert reward_fn.config.death_penalty == -1.0
+        assert reward_fn.config.timestep_penalty == -0.001
+
+    def test_custom_config(self) -> None:
+        """Test initialization with custom configuration."""
+        config = RewardConfig(kill_reward=5.0)
+        reward_fn = StandardRewardFunction(config)
+
+        assert reward_fn.config.kill_reward == 5.0
+
+    def test_initial_tracking_state(self) -> None:
+        """Test initial tracking state is zeroed."""
+        reward_fn = StandardRewardFunction()
+
+        stats = reward_fn.get_episode_stats()
+        assert stats["prev_kills"] == 0
+        assert stats["prev_deaths"] == 0
+
+    def test_get_config(self) -> None:
+        """Test get_config returns the configuration."""
+        config = RewardConfig(kill_reward=3.0)
+        reward_fn = StandardRewardFunction(config)
+
+        returned_config = reward_fn.get_config()
+        assert returned_config is config
+
+
+class TestStandardRewardFunctionReset:
+    """Tests for StandardRewardFunction reset method."""
+
+    def test_reset_with_stats(self) -> None:
+        """Test reset initializes tracking from stats."""
+        reward_fn = StandardRewardFunction()
+        stats = make_player_stats(kills=5, deaths=2)
+
+        reward_fn.reset(stats)
+
+        episode_stats = reward_fn.get_episode_stats()
+        assert episode_stats["prev_kills"] == 5
+        assert episode_stats["prev_deaths"] == 2
+
+    def test_reset_with_none(self) -> None:
+        """Test reset with None resets to zero."""
+        reward_fn = StandardRewardFunction()
+        # First set some values
+        reward_fn.reset(make_player_stats(kills=10, deaths=5))
+
+        # Then reset with None
+        reward_fn.reset(None)
+
+        episode_stats = reward_fn.get_episode_stats()
+        assert episode_stats["prev_kills"] == 0
+        assert episode_stats["prev_deaths"] == 0
+
+    def test_reset_clears_previous_state(self) -> None:
+        """Test reset clears any previous tracking state."""
+        reward_fn = StandardRewardFunction()
+
+        # Simulate some steps
+        reward_fn.reset(make_player_stats(kills=0, deaths=0))
+        reward_fn.calculate(make_player_stats(kills=3, deaths=1))
+
+        # Now reset with new initial values
+        reward_fn.reset(make_player_stats(kills=0, deaths=0))
+
+        episode_stats = reward_fn.get_episode_stats()
+        assert episode_stats["prev_kills"] == 0
+        assert episode_stats["prev_deaths"] == 0
+
+
+class TestStandardRewardFunctionCalculate:
+    """Tests for reward calculation."""
+
+    def test_reward_for_single_kill(self) -> None:
+        """Test reward for a single kill."""
+        reward_fn = StandardRewardFunction()
+        reward_fn.reset(make_player_stats(kills=0, deaths=0))
+
+        reward = reward_fn.calculate(make_player_stats(kills=1, deaths=0))
+
+        # +1.0 for kill, -0.001 timestep
+        assert reward == pytest.approx(1.0 - 0.001, abs=0.0001)
+
+    def test_reward_for_single_death(self) -> None:
+        """Test penalty for a single death."""
+        reward_fn = StandardRewardFunction()
+        reward_fn.reset(make_player_stats(kills=0, deaths=0))
+
+        reward = reward_fn.calculate(make_player_stats(kills=0, deaths=1))
+
+        # -1.0 for death, -0.001 timestep
+        assert reward == pytest.approx(-1.0 - 0.001, abs=0.0001)
+
+    def test_timestep_penalty_only(self) -> None:
+        """Test only timestep penalty when no kills/deaths."""
+        reward_fn = StandardRewardFunction()
+        reward_fn.reset(make_player_stats(kills=0, deaths=0))
+
+        reward = reward_fn.calculate(make_player_stats(kills=0, deaths=0))
+
+        assert reward == pytest.approx(-0.001, abs=0.0001)
+
+    def test_kill_and_death_same_step(self) -> None:
+        """Test reward when both kill and death occur in same step."""
+        reward_fn = StandardRewardFunction()
+        reward_fn.reset(make_player_stats(kills=0, deaths=0))
+
+        reward = reward_fn.calculate(make_player_stats(kills=1, deaths=1))
+
+        # +1.0 kill, -1.0 death, -0.001 timestep = -0.001
+        assert reward == pytest.approx(-0.001, abs=0.0001)
+
+    def test_multiple_kills_single_step(self) -> None:
+        """Test reward for multiple kills in one step (e.g., double kill)."""
+        reward_fn = StandardRewardFunction()
+        reward_fn.reset(make_player_stats(kills=0, deaths=0))
+
+        reward = reward_fn.calculate(make_player_stats(kills=3, deaths=0))
+
+        # 3 * 1.0 = 3.0, -0.001 timestep
+        assert reward == pytest.approx(3.0 - 0.001, abs=0.0001)
+
+    def test_delta_based_tracking(self) -> None:
+        """Test that rewards are delta-based, not absolute."""
+        reward_fn = StandardRewardFunction()
+        reward_fn.reset(make_player_stats(kills=5, deaths=2))
+
+        # Stats show 6 kills, 2 deaths (1 new kill, 0 new deaths)
+        reward = reward_fn.calculate(make_player_stats(kills=6, deaths=2))
+
+        # Only +1.0 for the new kill
+        assert reward == pytest.approx(1.0 - 0.001, abs=0.0001)
+
+    def test_consecutive_steps_tracking(self) -> None:
+        """Test correct tracking across consecutive steps."""
+        reward_fn = StandardRewardFunction()
+        reward_fn.reset(make_player_stats(kills=0, deaths=0))
+
+        # Step 1: get a kill
+        reward1 = reward_fn.calculate(make_player_stats(kills=1, deaths=0))
+        assert reward1 == pytest.approx(1.0 - 0.001, abs=0.0001)
+
+        # Step 2: no change
+        reward2 = reward_fn.calculate(make_player_stats(kills=1, deaths=0))
+        assert reward2 == pytest.approx(-0.001, abs=0.0001)
+
+        # Step 3: die
+        reward3 = reward_fn.calculate(make_player_stats(kills=1, deaths=1))
+        assert reward3 == pytest.approx(-1.0 - 0.001, abs=0.0001)
+
+        # Step 4: get another kill
+        reward4 = reward_fn.calculate(make_player_stats(kills=2, deaths=1))
+        assert reward4 == pytest.approx(1.0 - 0.001, abs=0.0001)
+
+    def test_calculate_with_none_stats(self) -> None:
+        """Test calculate returns only timestep penalty when stats are None."""
+        reward_fn = StandardRewardFunction()
+        reward_fn.reset(make_player_stats(kills=0, deaths=0))
+
+        reward = reward_fn.calculate(None)
+
+        assert reward == pytest.approx(-0.001, abs=0.0001)
+
+    def test_none_stats_does_not_update_tracking(self) -> None:
+        """Test that None stats doesn't update internal tracking."""
+        reward_fn = StandardRewardFunction()
+        reward_fn.reset(make_player_stats(kills=5, deaths=2))
+
+        # Calculate with None
+        reward_fn.calculate(None)
+
+        # Tracking should still be at initial values
+        stats = reward_fn.get_episode_stats()
+        assert stats["prev_kills"] == 5
+        assert stats["prev_deaths"] == 2
+
+
+class TestStandardRewardFunctionCustomConfig:
+    """Tests with custom reward configurations."""
+
+    def test_custom_kill_reward(self) -> None:
+        """Test reward with custom kill reward value."""
+        config = RewardConfig(kill_reward=5.0)
+        reward_fn = StandardRewardFunction(config)
+        reward_fn.reset(make_player_stats(kills=0, deaths=0))
+
+        reward = reward_fn.calculate(make_player_stats(kills=1, deaths=0))
+
+        assert reward == pytest.approx(5.0 - 0.001, abs=0.0001)
+
+    def test_custom_death_penalty(self) -> None:
+        """Test reward with custom death penalty value."""
+        config = RewardConfig(death_penalty=-2.0)
+        reward_fn = StandardRewardFunction(config)
+        reward_fn.reset(make_player_stats(kills=0, deaths=0))
+
+        reward = reward_fn.calculate(make_player_stats(kills=0, deaths=1))
+
+        assert reward == pytest.approx(-2.0 - 0.001, abs=0.0001)
+
+    def test_custom_timestep_penalty(self) -> None:
+        """Test reward with custom timestep penalty."""
+        config = RewardConfig(timestep_penalty=-0.01)
+        reward_fn = StandardRewardFunction(config)
+        reward_fn.reset(make_player_stats(kills=0, deaths=0))
+
+        reward = reward_fn.calculate(make_player_stats(kills=0, deaths=0))
+
+        assert reward == pytest.approx(-0.01, abs=0.0001)
+
+    def test_zero_timestep_penalty(self) -> None:
+        """Test reward with zero timestep penalty."""
+        config = RewardConfig(timestep_penalty=0.0)
+        reward_fn = StandardRewardFunction(config)
+        reward_fn.reset(make_player_stats(kills=0, deaths=0))
+
+        reward = reward_fn.calculate(make_player_stats(kills=1, deaths=0))
+
+        assert reward == pytest.approx(1.0, abs=0.0001)
+
+    def test_asymmetric_kill_death_values(self) -> None:
+        """Test with asymmetric kill/death values."""
+        config = RewardConfig(kill_reward=2.0, death_penalty=-0.5)
+        reward_fn = StandardRewardFunction(config)
+        reward_fn.reset(make_player_stats(kills=0, deaths=0))
+
+        # Kill and death in same step
+        reward = reward_fn.calculate(make_player_stats(kills=1, deaths=1))
+
+        # 2.0 - 0.5 - 0.001 = 1.499
+        assert reward == pytest.approx(1.499, abs=0.0001)
+
+
+class TestRewardIntegrationWithEnv:
+    """Integration tests for reward function with TowerfallEnv."""
+
+    def test_env_uses_reward_function(self) -> None:
+        """Test that TowerfallEnv uses the reward function correctly."""
+        from unittest.mock import MagicMock
+
+        from bot.gym import TowerfallEnv
+        from bot.models import GameState, PlayerState
+
+        env = TowerfallEnv()
+        env._client = MagicMock()
+        env._client.player_id = "player-456"
+
+        player_state_dict: dict[str, Any] = {
+            "id": "player-456",
+            "objectType": "player",
+            "name": "TestPlayer",
+            "x": 400.0,
+            "y": 300.0,
+            "dx": 0.0,
+            "dy": 0.0,
+            "dir": 0.0,
+            "rad": 20.0,
+            "h": 100,
+            "dead": False,
+            "sht": False,
+            "jc": 2,
+            "ac": 3,
+        }
+        game_state = GameState(
+            players={"player-456": PlayerState.model_validate(player_state_dict)},
+            canvas_size_x=800,
+            canvas_size_y=600,
+        )
+
+        # Test reward calculation
+        stats = {"player-456": make_player_stats(kills=1, deaths=0)}
+        reward = env._calculate_reward(game_state, stats)
+
+        # Should use reward function
+        assert reward == pytest.approx(1.0 - 0.001, abs=0.0001)
+
+    def test_env_custom_reward_config(self) -> None:
+        """Test TowerfallEnv with custom reward configuration."""
+        from bot.gym import RewardConfig, TowerfallEnv
+
+        config = RewardConfig(kill_reward=10.0, timestep_penalty=-0.1)
+        env = TowerfallEnv(reward_config=config)
+
+        assert env._reward_fn.config.kill_reward == 10.0
+        assert env._reward_fn.config.timestep_penalty == -0.1
+
+    def test_env_reset_resets_reward_function(self) -> None:
+        """Test that env.reset() resets the reward function tracking."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from bot.gym import TowerfallEnv
+        from bot.models import GameState, PlayerState
+
+        env = TowerfallEnv()
+
+        player_state_dict: dict[str, Any] = {
+            "id": "player-456",
+            "objectType": "player",
+            "name": "TestPlayer",
+            "x": 400.0,
+            "y": 300.0,
+            "dx": 0.0,
+            "dy": 0.0,
+            "dir": 0.0,
+            "rad": 20.0,
+            "h": 100,
+            "dead": False,
+            "sht": False,
+            "jc": 2,
+            "ac": 3,
+        }
+        game_state = GameState(
+            players={"player-456": PlayerState.model_validate(player_state_dict)},
+            canvas_size_x=800,
+            canvas_size_y=600,
+        )
+        info_dict = {
+            "room_id": "room-123",
+            "room_code": "ABC123",
+            "player_id": "player-456",
+        }
+
+        # Manually set some tracking state
+        env._reward_fn._prev_kills = 100
+        env._reward_fn._prev_deaths = 50
+
+        with patch.object(
+            env, "_async_reset", new=AsyncMock(return_value=(game_state, info_dict))
+        ):
+            env._client = MagicMock()
+            env._client.player_id = "player-456"
+
+            env.reset()
+
+        # Verify tracking was reset
+        stats = env._reward_fn.get_episode_stats()
+        assert stats["prev_kills"] == 0
+        assert stats["prev_deaths"] == 0
+
+
+class TestImports:
+    """Tests for module imports."""
+
+    def test_import_from_bot_gym(self) -> None:
+        """Test importing reward classes from bot.gym."""
+        from bot.gym import RewardConfig, RewardFunction, StandardRewardFunction
+
+        assert RewardConfig is not None
+        assert RewardFunction is not None
+        assert StandardRewardFunction is not None
+
+    def test_import_from_reward_module(self) -> None:
+        """Test importing directly from reward module."""
+        from bot.gym.reward import RewardConfig, StandardRewardFunction
+
+        assert RewardConfig is not None
+        assert StandardRewardFunction is not None


### PR DESCRIPTION
## Issue Reference
Closes #43 - Implement reward function

## Summary

This PR implements the reward function for the TowerFall RL Gym environment as specified in TASK-015. The reward function provides appropriate training signals to reinforce learning agents, incentivizing aggressive play (kills) while penalizing deaths and encouraging efficient gameplay through time penalties.

### Key Changes

- **New `RewardConfig` dataclass** with configurable reward parameters:
  - `kill_reward`: +1.0 (default) per kill
  - `death_penalty`: -1.0 (default) per death
  - `timestep_penalty`: -0.001 (default) per step

- **New `StandardRewardFunction` class** implementing delta-based reward calculation:
  - Tracks kills/deaths across steps to calculate deltas
  - Properly resets tracking state between episodes
  - Handles edge cases (None stats, multiple kills/deaths per step)

- **Integration with `TowerfallEnv`**:
  - Added `reward_config` parameter to environment constructor
  - Replaced inline reward calculation with `StandardRewardFunction`
  - Updated `reset()` to initialize reward function tracking

- **Comprehensive test coverage** (438 lines in `test_reward.py`):
  - Unit tests for `RewardConfig` defaults and custom values
  - Unit tests for `StandardRewardFunction` initialization, reset, and calculation
  - Tests for edge cases (None stats, multiple kills/deaths, consecutive steps)
  - Integration tests verifying env uses reward function correctly

## Files Changed

| File | Changes |
|------|---------|
| `bot2/src/bot/gym/reward.py` | New file - reward function implementation |
| `bot2/src/bot/gym/towerfall_env.py` | Integrated reward function into environment |
| `bot2/src/bot/gym/__init__.py` | Exported reward types, added usage examples |
| `bot2/tests/test_reward.py` | New file - comprehensive reward function tests |
| `bot2/tests/test_env.py` | Updated tests to use new reward function API |

## Design Rationale

The reward values are tuned to optimize the kill/death ratio (the "better" threshold from project requirements):

- **Symmetric kill/death values (+1.0/-1.0)**: Creates balanced incentive around K/D ratio
- **Small timestep penalty (-0.001)**: Encourages efficient play without dominating the reward signal, prevents passive strategies
- **Delta-based tracking**: Rewards reflect changes in state, not absolute values

## Test Plan

- [x] Unit tests pass for `RewardConfig` initialization
- [x] Unit tests pass for `StandardRewardFunction` methods
- [x] Kill detection correctly identifies when agent scores a kill
- [x] Death detection correctly identifies when agent dies
- [x] Timestep penalty applied on every step
- [x] Integration tests verify reward function works with `TowerfallEnv`
- [x] Existing environment tests updated and passing
