### PR TITLE
Model Registry for Successive Training Pipeline

### DIFF
--- a/bot2/src/bot/agent/__init__.py
+++ b/bot2/src/bot/agent/__init__.py
@@ -8,8 +8,8 @@ from bot.agent.network import ActorCriticNetwork
 from bot.agent.ppo_trainer import PPOConfig, PPOTrainer
 from bot.agent.rollout_buffer import RolloutBuffer
 from bot.agent.serialization import (
+    CheckpointMetadata,
     ModelCheckpoint,
-    ModelMetadata,
     generate_model_filename,
     get_checkpoint_info,
     load_model,
@@ -18,8 +18,8 @@ from bot.agent.serialization import (
 
 __all__ = [
     "ActorCriticNetwork",
+    "CheckpointMetadata",
     "ModelCheckpoint",
-    "ModelMetadata",
     "PPOConfig",
     "PPOTrainer",
     "RolloutBuffer",

--- a/bot2/src/bot/agent/serialization.py
+++ b/bot2/src/bot/agent/serialization.py
@@ -17,7 +17,7 @@ from bot.agent.network import ActorCriticNetwork
 
 
 @dataclass
-class ModelMetadata:
+class CheckpointMetadata:
     """Metadata for a saved model checkpoint.
 
     Attributes:
@@ -56,7 +56,7 @@ class ModelCheckpoint:
         optimizer_state_dict: Optional optimizer state for training resumption
         training_step: Current training step/update number
         total_timesteps: Total environment steps collected
-        metadata: Model metadata including version and architecture
+        metadata: Checkpoint metadata including version and architecture
         hyperparameters: Hyperparameters used during training
     """
 
@@ -64,7 +64,7 @@ class ModelCheckpoint:
     optimizer_state_dict: dict[str, Any] | None
     training_step: int
     total_timesteps: int
-    metadata: ModelMetadata
+    metadata: CheckpointMetadata
     hyperparameters: dict[str, Any] = field(default_factory=dict)
 
 
@@ -216,7 +216,7 @@ def load_model(
     meta = checkpoint["metadata"]
     training_info = meta.get("training_info", {})
 
-    metadata = ModelMetadata(
+    metadata = CheckpointMetadata(
         version=meta["version"],
         created_at=datetime.fromisoformat(meta["created_at"]),
         observation_size=arch["observation_size"],
@@ -241,7 +241,7 @@ def load_model(
     return network, checkpoint_data
 
 
-def get_checkpoint_info(path: str | Path) -> ModelMetadata:
+def get_checkpoint_info(path: str | Path) -> CheckpointMetadata:
     """Read checkpoint metadata from a checkpoint file.
 
     Useful for listing available models or checking compatibility.
@@ -254,7 +254,7 @@ def get_checkpoint_info(path: str | Path) -> ModelMetadata:
         path: Path to the checkpoint file
 
     Returns:
-        ModelMetadata with checkpoint information
+        CheckpointMetadata with checkpoint information
 
     Raises:
         FileNotFoundError: If checkpoint file doesn't exist
@@ -277,7 +277,7 @@ def get_checkpoint_info(path: str | Path) -> ModelMetadata:
     arch = meta["architecture"]
     training_info = meta.get("training_info", {})
 
-    return ModelMetadata(
+    return CheckpointMetadata(
         version=meta["version"],
         created_at=datetime.fromisoformat(meta["created_at"]),
         observation_size=arch["observation_size"],

--- a/bot2/src/bot/training/__init__.py
+++ b/bot2/src/bot/training/__init__.py
@@ -2,6 +2,7 @@
 
 This module provides components for managing game server instances during
 ML training, including game creation, lifecycle management, and cleanup.
+It also provides the model registry for storing and retrieving trained models.
 
 Usage:
     from bot.training import GameServerManager, TrainingGameConfig, GameInstance
@@ -10,6 +11,11 @@ Usage:
         config = TrainingGameConfig(room_name="Training Session")
         game = await manager.create_game(config, "Bot1")
         # Use game for training...
+
+    from bot.training import ModelRegistry, TrainingMetrics
+
+    registry = ModelRegistry("/path/to/registry")
+    model_id = registry.register_model(...)
 """
 
 from bot.training.exceptions import (
@@ -18,6 +24,16 @@ from bot.training.exceptions import (
     GameServerError,
     MaxGamesExceededError,
 )
+from bot.training.registry import (
+    ModelAlreadyExistsError,
+    ModelMetadata,
+    ModelNotFoundError,
+    ModelRegistry,
+    NetworkArchitecture,
+    RegistryIndex,
+    StorageBackend,
+    TrainingMetrics,
+)
 from bot.training.server_manager import (
     GameInstance,
     GameServerManager,
@@ -25,13 +41,22 @@ from bot.training.server_manager import (
 )
 
 __all__ = [
-    # Main classes
+    # Server management
     "GameServerManager",
     "TrainingGameConfig",
     "GameInstance",
+    # Model registry
+    "ModelRegistry",
+    "TrainingMetrics",
+    "ModelMetadata",
+    "NetworkArchitecture",
+    "StorageBackend",
+    "RegistryIndex",
     # Exceptions
     "GameServerError",
     "GameCreationError",
     "MaxGamesExceededError",
     "GameNotFoundError",
+    "ModelNotFoundError",
+    "ModelAlreadyExistsError",
 ]

--- a/bot2/src/bot/training/registry/__init__.py
+++ b/bot2/src/bot/training/registry/__init__.py
@@ -1,0 +1,62 @@
+"""Model Registry module for managing trained PPO models.
+
+This module provides components for storing, versioning, and retrieving
+trained models with associated metadata. It is a core part of the
+successive training pipeline.
+
+Usage:
+    from bot.training.registry import ModelRegistry, TrainingMetrics
+
+    registry = ModelRegistry("/path/to/registry")
+
+    # Create training metrics
+    metrics = TrainingMetrics(
+        total_episodes=1000,
+        total_timesteps=100000,
+        average_reward=50.0,
+        average_episode_length=500.0,
+        win_rate=0.6,
+        average_kills=2.5,
+        average_deaths=1.5,
+        kills_deaths_ratio=1.67,
+    )
+
+    # Register a trained model
+    model_id = registry.register_model(
+        model=trained_network,
+        generation=0,
+        opponent_model_id=None,
+        training_metrics=metrics,
+        hyperparameters=config.model_dump(),
+        training_duration_seconds=3600.0,
+    )
+
+    # Retrieve a model
+    network, metadata = registry.get_model(model_id)
+"""
+
+from bot.training.registry.model_metadata import (
+    ModelMetadata,
+    NetworkArchitecture,
+    TrainingMetrics,
+)
+from bot.training.registry.model_registry import (
+    ModelAlreadyExistsError,
+    ModelNotFoundError,
+    ModelRegistry,
+)
+from bot.training.registry.storage_backend import RegistryIndex, StorageBackend
+
+__all__ = [
+    # Main classes
+    "ModelRegistry",
+    "TrainingMetrics",
+    "ModelMetadata",
+    "NetworkArchitecture",
+    # Storage
+    "StorageBackend",
+    "RegistryIndex",
+    # Exceptions
+    "ModelNotFoundError",
+    "ModelAlreadyExistsError",
+]

--- a/bot2/src/bot/training/registry/model_metadata.py
+++ b/bot2/src/bot/training/registry/model_metadata.py
@@ -1,0 +1,108 @@
+"""Model metadata Pydantic models for the model registry.
+
+This module defines the data models for tracking model versions, training metrics,
+and metadata in the model registry system.
+"""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class TrainingMetrics(BaseModel):
+    """Metrics captured during training.
+
+    These metrics track the performance of a trained model and are used
+    to compare models across generations in the successive training pipeline.
+
+    Attributes:
+        total_episodes: Number of episodes completed during training
+        total_timesteps: Total environment steps collected
+        average_reward: Mean episode reward during training
+        average_episode_length: Mean episode length in timesteps
+        win_rate: Percentage of episodes won (0.0 to 1.0)
+        average_kills: Mean kills per episode
+        average_deaths: Mean deaths per episode
+        kills_deaths_ratio: Ratio of kills to deaths (the "better" metric)
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    total_episodes: int = Field(ge=0, description="Number of episodes completed")
+    total_timesteps: int = Field(ge=0, description="Total environment steps collected")
+    average_reward: float = Field(description="Mean episode reward")
+    average_episode_length: float = Field(ge=0, description="Mean episode length")
+    win_rate: float = Field(
+        ge=0.0, le=1.0, description="Percentage of episodes won (0.0 to 1.0)"
+    )
+    average_kills: float = Field(ge=0, description="Mean kills per episode")
+    average_deaths: float = Field(ge=0, description="Mean deaths per episode")
+    kills_deaths_ratio: float = Field(
+        ge=0, description="Ratio of kills to deaths (K/D ratio)"
+    )
+
+
+class NetworkArchitecture(BaseModel):
+    """Neural network architecture parameters.
+
+    These parameters define the structure of the saved model and are used
+    to validate compatibility when loading models.
+
+    Attributes:
+        observation_size: Dimension of the observation vector
+        action_size: Number of discrete actions
+        hidden_size: Size of shared feature extractor layers
+        actor_hidden: Size of actor head hidden layer
+        critic_hidden: Size of critic head hidden layer
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    observation_size: int = Field(gt=0, description="Observation vector dimension")
+    action_size: int = Field(gt=0, description="Number of discrete actions")
+    hidden_size: int = Field(gt=0, default=256, description="Shared hidden layer size")
+    actor_hidden: int = Field(gt=0, default=128, description="Actor hidden layer size")
+    critic_hidden: int = Field(
+        gt=0, default=128, description="Critic hidden layer size"
+    )
+
+
+class ModelMetadata(BaseModel):
+    """Metadata for a registered model.
+
+    This model contains all the information needed to track, retrieve,
+    and compare trained models in the registry.
+
+    Attributes:
+        model_id: Unique identifier for this model (e.g., "ppo_gen_003")
+        generation: Generation number in successive training (0 for first model)
+        created_at: Timestamp when the model was registered
+        training_duration_seconds: Total training time in seconds
+        opponent_model_id: ID of opponent model trained against (None for gen 0)
+        training_metrics: Performance metrics from training
+        hyperparameters: PPO hyperparameters used during training
+        architecture: Neural network architecture parameters
+        checkpoint_path: Relative path to the serialized model file
+        notes: Optional human-readable notes about this model
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    model_id: str = Field(description="Unique model identifier (e.g., ppo_gen_003)")
+    generation: int = Field(
+        ge=0, description="Generation number in successive training"
+    )
+    created_at: datetime = Field(description="Timestamp when model was registered")
+    training_duration_seconds: float = Field(
+        ge=0, description="Total training time in seconds"
+    )
+    opponent_model_id: str | None = Field(
+        default=None, description="ID of opponent model trained against"
+    )
+    training_metrics: TrainingMetrics = Field(description="Performance metrics")
+    hyperparameters: dict = Field(
+        default_factory=dict, description="PPO hyperparameters used"
+    )
+    architecture: NetworkArchitecture = Field(description="Neural network architecture")
+    checkpoint_path: str = Field(description="Relative path to serialized model file")
+    notes: str | None = Field(default=None, description="Optional notes about model")

--- a/bot2/src/bot/training/registry/model_registry.py
+++ b/bot2/src/bot/training/registry/model_registry.py
@@ -1,0 +1,374 @@
+"""Model Registry for storing, versioning, and retrieving trained PPO models.
+
+This module provides the main ModelRegistry class for managing trained models
+with associated metadata as part of the successive training pipeline.
+"""
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import torch
+
+from bot.agent.network import ActorCriticNetwork
+from bot.agent.serialization import load_model, save_model
+from bot.training.registry.model_metadata import (
+    ModelMetadata,
+    NetworkArchitecture,
+    TrainingMetrics,
+)
+from bot.training.registry.storage_backend import StorageBackend
+
+if TYPE_CHECKING:
+    from bot.agent.serialization import ModelCheckpoint
+
+
+class ModelNotFoundError(Exception):
+    """Raised when a requested model is not found in the registry."""
+
+
+class ModelAlreadyExistsError(Exception):
+    """Raised when attempting to register a model with an existing ID."""
+
+
+class ModelRegistry:
+    """Registry for storing and retrieving trained PPO models.
+
+    The model registry provides:
+    - Persistent storage of trained models with versioning
+    - Metadata tracking for performance comparison
+    - Generation-based retrieval for successive training
+    - Thread-safe operations with file locking
+
+    Example usage:
+        registry = ModelRegistry("/path/to/registry")
+
+        # Register a new model
+        model_id = registry.register_model(
+            model=trained_network,
+            generation=0,
+            opponent_model_id=None,
+            training_metrics=metrics,
+            hyperparameters=config.model_dump(),
+            training_duration_seconds=3600.0,
+        )
+
+        # Retrieve a model
+        network, metadata = registry.get_model(model_id)
+
+        # Get the best model for comparison
+        best_network, best_meta = registry.get_best_model()
+
+    Attributes:
+        registry_path: Path to the registry storage directory
+    """
+
+    MODEL_ID_FORMAT = "ppo_gen_{generation:03d}"
+
+    def __init__(self, registry_path: str | Path):
+        """Initialize the model registry.
+
+        Args:
+            registry_path: Path to the registry storage directory.
+                           Will be created if it doesn't exist.
+        """
+        self.registry_path = Path(registry_path)
+        self._backend = StorageBackend(self.registry_path)
+        self._backend.initialize()
+
+    def _generate_model_id(self, generation: int) -> str:
+        """Generate a model ID for a given generation.
+
+        Args:
+            generation: Generation number
+
+        Returns:
+            Model ID in format "ppo_gen_XXX"
+        """
+        return self.MODEL_ID_FORMAT.format(generation=generation)
+
+    def register_model(
+        self,
+        model: ActorCriticNetwork,
+        generation: int,
+        opponent_model_id: str | None,
+        training_metrics: TrainingMetrics,
+        hyperparameters: dict,
+        training_duration_seconds: float,
+        optimizer: torch.optim.Optimizer | None = None,
+        training_step: int = 0,
+        notes: str | None = None,
+    ) -> str:
+        """Register a new model in the registry.
+
+        Saves the model weights to disk and stores associated metadata
+        in the registry index.
+
+        Args:
+            model: Trained ActorCriticNetwork to register
+            generation: Generation number (0 for first model)
+            opponent_model_id: ID of model trained against (None for gen 0)
+            training_metrics: Performance metrics from training
+            hyperparameters: PPO hyperparameters used during training
+            training_duration_seconds: Total training time in seconds
+            optimizer: Optional optimizer to save for training resumption
+            training_step: Current training step/update number
+            notes: Optional human-readable notes
+
+        Returns:
+            The assigned model_id
+
+        Raises:
+            ModelAlreadyExistsError: If model for this generation already exists
+        """
+        model_id = self._generate_model_id(generation)
+
+        if self._backend.model_exists(model_id):
+            raise ModelAlreadyExistsError(
+                f"Model with ID '{model_id}' already exists in registry"
+            )
+
+        # Create checkpoint path relative to models directory
+        checkpoint_rel_path = f"models/{model_id}/model.pt"
+        checkpoint_path = self._backend.get_checkpoint_path(model_id)
+
+        # Save the model checkpoint using existing serialization
+        training_info = {
+            "total_episodes": training_metrics.total_episodes,
+            "final_reward": training_metrics.average_reward,
+            "opponent_version": opponent_model_id,
+        }
+
+        save_model(
+            network=model,
+            path=checkpoint_path,
+            version=model_id,
+            training_step=training_step,
+            total_timesteps=training_metrics.total_timesteps,
+            optimizer=optimizer,
+            training_info=training_info,
+            hyperparameters=hyperparameters,
+        )
+
+        # Create and store metadata
+        architecture = NetworkArchitecture(
+            observation_size=model.observation_size,
+            action_size=model.action_size,
+            hidden_size=model.hidden_size,
+            actor_hidden=model.actor_hidden,
+            critic_hidden=model.critic_hidden,
+        )
+
+        metadata = ModelMetadata(
+            model_id=model_id,
+            generation=generation,
+            created_at=datetime.now(timezone.utc),
+            training_duration_seconds=training_duration_seconds,
+            opponent_model_id=opponent_model_id,
+            training_metrics=training_metrics,
+            hyperparameters=hyperparameters,
+            architecture=architecture,
+            checkpoint_path=checkpoint_rel_path,
+            notes=notes,
+        )
+
+        self._backend.save_metadata(metadata)
+
+        return model_id
+
+    def get_model(
+        self,
+        model_id: str,
+        device: torch.device | str = "cpu",
+    ) -> tuple[ActorCriticNetwork, ModelMetadata]:
+        """Load a model and its metadata by ID.
+
+        Args:
+            model_id: Unique model identifier
+            device: Device to load the model onto
+
+        Returns:
+            Tuple of (ActorCriticNetwork, ModelMetadata)
+
+        Raises:
+            ModelNotFoundError: If model is not found
+        """
+        metadata = self._backend.load_metadata(model_id)
+        if metadata is None:
+            raise ModelNotFoundError(f"Model '{model_id}' not found in registry")
+
+        checkpoint_path = self._backend.get_checkpoint_path(model_id)
+        network, _ = load_model(checkpoint_path, device=device)
+
+        return network, metadata
+
+    def get_latest_model(
+        self,
+        device: torch.device | str = "cpu",
+    ) -> tuple[ActorCriticNetwork, ModelMetadata] | None:
+        """Get the most recently registered model.
+
+        Args:
+            device: Device to load the model onto
+
+        Returns:
+            Tuple of (ActorCriticNetwork, ModelMetadata) or None if empty
+        """
+        all_metadata = self._backend.list_all_metadata()
+        if not all_metadata:
+            return None
+
+        # Sort by created_at and get the latest
+        latest = max(all_metadata, key=lambda m: m.created_at)
+        return self.get_model(latest.model_id, device=device)
+
+    def get_model_by_generation(
+        self,
+        generation: int,
+        device: torch.device | str = "cpu",
+    ) -> tuple[ActorCriticNetwork, ModelMetadata] | None:
+        """Get model for a specific generation.
+
+        Args:
+            generation: Generation number to retrieve
+            device: Device to load the model onto
+
+        Returns:
+            Tuple of (ActorCriticNetwork, ModelMetadata) or None if not found
+        """
+        model_id = self._generate_model_id(generation)
+        try:
+            return self.get_model(model_id, device=device)
+        except ModelNotFoundError:
+            return None
+
+    def list_models(self) -> list[ModelMetadata]:
+        """List all registered models with their metadata.
+
+        Returns:
+            List of ModelMetadata for all registered models,
+            sorted by generation
+        """
+        all_metadata = self._backend.list_all_metadata()
+        return sorted(all_metadata, key=lambda m: m.generation)
+
+    def get_best_model(
+        self,
+        device: torch.device | str = "cpu",
+    ) -> tuple[ActorCriticNetwork, ModelMetadata] | None:
+        """Get the model with the highest kills/deaths ratio.
+
+        This is the primary comparison metric for the successive
+        training pipeline.
+
+        Args:
+            device: Device to load the model onto
+
+        Returns:
+            Tuple of (ActorCriticNetwork, ModelMetadata) or None if empty
+        """
+        all_metadata = self._backend.list_all_metadata()
+        if not all_metadata:
+            return None
+
+        best = max(
+            all_metadata,
+            key=lambda m: m.training_metrics.kills_deaths_ratio,
+        )
+        return self.get_model(best.model_id, device=device)
+
+    def is_better_than(self, model_id_a: str, model_id_b: str) -> bool:
+        """Compare two models based on kills/deaths ratio.
+
+        Args:
+            model_id_a: First model to compare
+            model_id_b: Second model to compare
+
+        Returns:
+            True if model_a has higher K/D ratio than model_b
+
+        Raises:
+            ModelNotFoundError: If either model is not found
+        """
+        metadata_a = self._backend.load_metadata(model_id_a)
+        metadata_b = self._backend.load_metadata(model_id_b)
+
+        if metadata_a is None:
+            raise ModelNotFoundError(f"Model '{model_id_a}' not found in registry")
+        if metadata_b is None:
+            raise ModelNotFoundError(f"Model '{model_id_b}' not found in registry")
+
+        return (
+            metadata_a.training_metrics.kills_deaths_ratio
+            > metadata_b.training_metrics.kills_deaths_ratio
+        )
+
+    def delete_model(self, model_id: str) -> bool:
+        """Remove a model from the registry.
+
+        Deletes both the checkpoint files and metadata.
+
+        Args:
+            model_id: Unique model identifier
+
+        Returns:
+            True if model was deleted, False if not found
+        """
+        return self._backend.delete_model(model_id)
+
+    def get_next_generation(self) -> int:
+        """Get the next available generation number.
+
+        Useful for determining the generation number for a new model
+        in the successive training pipeline.
+
+        Returns:
+            Next generation number (0 if registry is empty)
+        """
+        return self._backend.get_next_generation()
+
+    def get_checkpoint_data(
+        self, model_id: str, device: torch.device | str = "cpu"
+    ) -> "ModelCheckpoint":
+        """Get the full checkpoint data for a model.
+
+        Useful for accessing optimizer state for continued training.
+
+        Args:
+            model_id: Unique model identifier
+            device: Device to load the checkpoint onto
+
+        Returns:
+            ModelCheckpoint with full checkpoint data
+
+        Raises:
+            ModelNotFoundError: If model is not found
+        """
+        metadata = self._backend.load_metadata(model_id)
+        if metadata is None:
+            raise ModelNotFoundError(f"Model '{model_id}' not found in registry")
+
+        checkpoint_path = self._backend.get_checkpoint_path(model_id)
+        _, checkpoint = load_model(checkpoint_path, device=device)
+
+        return checkpoint
+
+    def get_metadata(self, model_id: str) -> ModelMetadata:
+        """Get metadata for a model without loading weights.
+
+        Useful for quick metadata queries without the overhead
+        of loading the full model.
+
+        Args:
+            model_id: Unique model identifier
+
+        Returns:
+            ModelMetadata for the model
+
+        Raises:
+            ModelNotFoundError: If model is not found
+        """
+        metadata = self._backend.load_metadata(model_id)
+        if metadata is None:
+            raise ModelNotFoundError(f"Model '{model_id}' not found in registry")
+        return metadata

--- a/bot2/src/bot/training/registry/storage_backend.py
+++ b/bot2/src/bot/training/registry/storage_backend.py
@@ -1,0 +1,276 @@
+"""File-based storage backend for the model registry.
+
+This module provides the file system operations for storing and retrieving
+model checkpoints and metadata with proper indexing for fast queries.
+"""
+
+import json
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+import filelock
+
+from bot.training.registry.model_metadata import ModelMetadata
+
+
+class RegistryIndex:
+    """Index of all registered models for fast metadata queries.
+
+    The index is stored as a JSON file and contains metadata for all
+    registered models. It enables fast queries without loading model weights.
+
+    Attributes:
+        models: Dictionary mapping model_id to ModelMetadata
+        last_updated: Timestamp of last index update
+    """
+
+    def __init__(
+        self,
+        models: dict[str, ModelMetadata] | None = None,
+        last_updated: datetime | None = None,
+    ):
+        """Initialize the registry index.
+
+        Args:
+            models: Dictionary mapping model_id to metadata
+            last_updated: Timestamp of last update
+        """
+        self.models = models or {}
+        self.last_updated = last_updated or datetime.now(timezone.utc)
+
+    def to_dict(self) -> dict:
+        """Serialize index to dictionary for JSON storage."""
+        return {
+            "models": {
+                model_id: metadata.model_dump(mode="json")
+                for model_id, metadata in self.models.items()
+            },
+            "last_updated": self.last_updated.isoformat(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "RegistryIndex":
+        """Deserialize index from dictionary."""
+        models = {
+            model_id: ModelMetadata.model_validate(meta)
+            for model_id, meta in data.get("models", {}).items()
+        }
+        last_updated = datetime.fromisoformat(data["last_updated"])
+        return cls(models=models, last_updated=last_updated)
+
+
+class StorageBackend:
+    """File-based storage backend for the model registry.
+
+    This backend provides persistent storage for model checkpoints and
+    metadata using the filesystem with proper locking for thread safety.
+
+    Directory structure:
+        registry_path/
+        ├── index.json           # Model index with all metadata
+        ├── index.json.lock      # Lock file for concurrent access
+        └── models/
+            ├── ppo_gen_000/
+            │   ├── model.pt     # PyTorch model checkpoint
+            │   └── metadata.json
+            ├── ppo_gen_001/
+            │   ├── model.pt
+            │   └── metadata.json
+            └── ...
+    """
+
+    INDEX_FILENAME = "index.json"
+    MODELS_DIR = "models"
+    MODEL_FILENAME = "model.pt"
+    METADATA_FILENAME = "metadata.json"
+    LOCK_TIMEOUT = 10.0  # seconds
+
+    def __init__(self, registry_path: str | Path):
+        """Initialize storage backend.
+
+        Args:
+            registry_path: Root directory for the registry storage
+        """
+        self.registry_path = Path(registry_path)
+        self._index_path = self.registry_path / self.INDEX_FILENAME
+        self._models_dir = self.registry_path / self.MODELS_DIR
+        self._lock_path = self.registry_path / f"{self.INDEX_FILENAME}.lock"
+        self._lock = filelock.FileLock(str(self._lock_path), timeout=self.LOCK_TIMEOUT)
+
+    def initialize(self) -> None:
+        """Initialize the storage directory structure.
+
+        Creates the registry directory and initializes an empty index
+        if they don't exist.
+        """
+        self.registry_path.mkdir(parents=True, exist_ok=True)
+        self._models_dir.mkdir(exist_ok=True)
+
+        if not self._index_path.exists():
+            self._write_index(RegistryIndex())
+
+    def _read_index(self) -> RegistryIndex:
+        """Read the registry index from disk.
+
+        Returns:
+            RegistryIndex with all registered models
+
+        Raises:
+            FileNotFoundError: If index file doesn't exist
+        """
+        if not self._index_path.exists():
+            return RegistryIndex()
+
+        with open(self._index_path, encoding="utf-8") as f:
+            data = json.load(f)
+        return RegistryIndex.from_dict(data)
+
+    def _write_index(self, index: RegistryIndex) -> None:
+        """Write the registry index to disk.
+
+        Args:
+            index: RegistryIndex to write
+        """
+        index.last_updated = datetime.now(timezone.utc)
+        with open(self._index_path, "w", encoding="utf-8") as f:
+            json.dump(index.to_dict(), f, indent=2)
+
+    def get_model_dir(self, model_id: str) -> Path:
+        """Get the directory path for a model.
+
+        Args:
+            model_id: Unique model identifier
+
+        Returns:
+            Path to the model's directory
+        """
+        return self._models_dir / model_id
+
+    def get_checkpoint_path(self, model_id: str) -> Path:
+        """Get the checkpoint file path for a model.
+
+        Args:
+            model_id: Unique model identifier
+
+        Returns:
+            Path to the model's checkpoint file
+        """
+        return self.get_model_dir(model_id) / self.MODEL_FILENAME
+
+    def get_metadata_path(self, model_id: str) -> Path:
+        """Get the metadata file path for a model.
+
+        Args:
+            model_id: Unique model identifier
+
+        Returns:
+            Path to the model's metadata file
+        """
+        return self.get_model_dir(model_id) / self.METADATA_FILENAME
+
+    def model_exists(self, model_id: str) -> bool:
+        """Check if a model exists in the registry.
+
+        Args:
+            model_id: Unique model identifier
+
+        Returns:
+            True if model exists, False otherwise
+        """
+        return self.get_checkpoint_path(model_id).exists()
+
+    def save_metadata(self, metadata: ModelMetadata) -> None:
+        """Save model metadata and update the index.
+
+        This method is thread-safe and uses file locking to prevent
+        concurrent writes.
+
+        Args:
+            metadata: ModelMetadata to save
+        """
+        model_dir = self.get_model_dir(metadata.model_id)
+        model_dir.mkdir(parents=True, exist_ok=True)
+
+        # Save individual metadata file
+        metadata_path = self.get_metadata_path(metadata.model_id)
+        with open(metadata_path, "w", encoding="utf-8") as f:
+            json.dump(metadata.model_dump(mode="json"), f, indent=2)
+
+        # Update the index with locking
+        with self._lock:
+            index = self._read_index()
+            index.models[metadata.model_id] = metadata
+            self._write_index(index)
+
+    def load_metadata(self, model_id: str) -> ModelMetadata | None:
+        """Load metadata for a specific model.
+
+        Args:
+            model_id: Unique model identifier
+
+        Returns:
+            ModelMetadata if found, None otherwise
+        """
+        metadata_path = self.get_metadata_path(model_id)
+        if not metadata_path.exists():
+            return None
+
+        with open(metadata_path, encoding="utf-8") as f:
+            data = json.load(f)
+        return ModelMetadata.model_validate(data)
+
+    def list_all_metadata(self) -> list[ModelMetadata]:
+        """List metadata for all registered models.
+
+        Uses the index for fast access without loading individual files.
+
+        Returns:
+            List of ModelMetadata for all registered models
+        """
+        with self._lock:
+            index = self._read_index()
+        return list(index.models.values())
+
+    def delete_model(self, model_id: str) -> bool:
+        """Delete a model from the registry.
+
+        This method is thread-safe and removes both the model files
+        and the index entry.
+
+        Args:
+            model_id: Unique model identifier
+
+        Returns:
+            True if model was deleted, False if not found
+        """
+        model_dir = self.get_model_dir(model_id)
+        if not model_dir.exists():
+            return False
+
+        # Remove directory and contents
+        shutil.rmtree(model_dir)
+
+        # Update the index with locking
+        with self._lock:
+            index = self._read_index()
+            if model_id in index.models:
+                del index.models[model_id]
+                self._write_index(index)
+
+        return True
+
+    def get_next_generation(self) -> int:
+        """Get the next available generation number.
+
+        Returns:
+            Next generation number (0 if no models registered)
+        """
+        with self._lock:
+            index = self._read_index()
+
+        if not index.models:
+            return 0
+
+        max_gen = max(meta.generation for meta in index.models.values())
+        return max_gen + 1

--- a/bot2/tests/integration/training/__init__.py
+++ b/bot2/tests/integration/training/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for training module."""

--- a/bot2/tests/integration/training/test_registry_integration.py
+++ b/bot2/tests/integration/training/test_registry_integration.py
@@ -1,0 +1,440 @@
+"""Integration tests for the model registry.
+
+These tests verify the complete workflow of model registration, storage,
+retrieval, and comparison across multiple generations.
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+import torch
+
+from bot.agent.network import ActorCriticNetwork
+from bot.training.registry import (
+    ModelRegistry,
+    TrainingMetrics,
+)
+
+
+@pytest.fixture
+def temp_registry_path():
+    """Create a temporary directory for registry storage."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir) / "registry"
+
+
+@pytest.fixture
+def registry(temp_registry_path: Path) -> ModelRegistry:
+    """Create a ModelRegistry with temporary storage."""
+    return ModelRegistry(temp_registry_path)
+
+
+class TestRegistryIntegration:
+    """Integration tests for model registry workflows."""
+
+    def test_register_retrieve_verify_weights_match(self, registry: ModelRegistry):
+        """Integration test: register model -> retrieve model -> verify weights match."""
+        # Create and train a network (simulate training by doing a forward pass)
+        network = ActorCriticNetwork(observation_size=114, action_size=27)
+
+        # Capture original weights for verification
+        original_state = {k: v.clone() for k, v in network.state_dict().items()}
+
+        # Run sample inference
+        sample_obs = torch.randn(1, 114)
+        original_logits, original_value = network(sample_obs)
+
+        # Create metrics
+        metrics = TrainingMetrics(
+            total_episodes=500,
+            total_timesteps=50000,
+            average_reward=45.0,
+            average_episode_length=450.0,
+            win_rate=0.55,
+            average_kills=2.0,
+            average_deaths=1.8,
+            kills_deaths_ratio=1.11,
+        )
+
+        hyperparams = {
+            "learning_rate": 3e-4,
+            "gamma": 0.99,
+            "clip_range": 0.2,
+        }
+
+        # Register model
+        model_id = registry.register_model(
+            model=network,
+            generation=0,
+            opponent_model_id=None,
+            training_metrics=metrics,
+            hyperparameters=hyperparams,
+            training_duration_seconds=1800.0,
+            notes="Integration test model",
+        )
+
+        # Retrieve model
+        loaded_network, metadata = registry.get_model(model_id)
+
+        # Verify weights match
+        loaded_state = loaded_network.state_dict()
+        for key in original_state:
+            assert torch.allclose(original_state[key], loaded_state[key]), (
+                f"Weight mismatch for {key}"
+            )
+
+        # Verify inference matches
+        loaded_logits, loaded_value = loaded_network(sample_obs)
+        assert torch.allclose(original_logits, loaded_logits)
+        assert torch.allclose(original_value, loaded_value)
+
+        # Verify metadata
+        assert metadata.model_id == model_id
+        assert metadata.generation == 0
+        assert metadata.training_metrics.kills_deaths_ratio == 1.11
+        assert metadata.notes == "Integration test model"
+
+    def test_successive_model_registration(self, registry: ModelRegistry):
+        """Integration test: register successive generations of models."""
+        base_hyperparams = {
+            "learning_rate": 3e-4,
+            "gamma": 0.99,
+        }
+
+        # Generation 0: initial model
+        gen0_network = ActorCriticNetwork(observation_size=114, action_size=27)
+        gen0_metrics = TrainingMetrics(
+            total_episodes=1000,
+            total_timesteps=100000,
+            average_reward=30.0,
+            average_episode_length=300.0,
+            win_rate=0.4,
+            average_kills=1.2,
+            average_deaths=2.0,
+            kills_deaths_ratio=0.6,
+        )
+
+        gen0_id = registry.register_model(
+            model=gen0_network,
+            generation=0,
+            opponent_model_id=None,
+            training_metrics=gen0_metrics,
+            hyperparameters=base_hyperparams,
+            training_duration_seconds=3600.0,
+        )
+
+        assert gen0_id == "ppo_gen_000"
+        assert registry.get_next_generation() == 1
+
+        # Generation 1: trained against gen0
+        gen1_network = ActorCriticNetwork(observation_size=114, action_size=27)
+        gen1_metrics = TrainingMetrics(
+            total_episodes=2000,
+            total_timesteps=200000,
+            average_reward=55.0,
+            average_episode_length=450.0,
+            win_rate=0.65,
+            average_kills=2.5,
+            average_deaths=1.5,
+            kills_deaths_ratio=1.67,
+        )
+
+        gen1_id = registry.register_model(
+            model=gen1_network,
+            generation=1,
+            opponent_model_id="ppo_gen_000",
+            training_metrics=gen1_metrics,
+            hyperparameters=base_hyperparams,
+            training_duration_seconds=7200.0,
+        )
+
+        assert gen1_id == "ppo_gen_001"
+        assert registry.get_next_generation() == 2
+
+        # Generation 2: trained against gen1
+        gen2_network = ActorCriticNetwork(observation_size=114, action_size=27)
+        gen2_metrics = TrainingMetrics(
+            total_episodes=3000,
+            total_timesteps=300000,
+            average_reward=75.0,
+            average_episode_length=550.0,
+            win_rate=0.8,
+            average_kills=3.5,
+            average_deaths=1.0,
+            kills_deaths_ratio=3.5,
+        )
+
+        gen2_id = registry.register_model(
+            model=gen2_network,
+            generation=2,
+            opponent_model_id="ppo_gen_001",
+            training_metrics=gen2_metrics,
+            hyperparameters=base_hyperparams,
+            training_duration_seconds=10800.0,
+        )
+
+        assert gen2_id == "ppo_gen_002"
+
+        # Verify model list
+        models = registry.list_models()
+        assert len(models) == 3
+        assert [m.generation for m in models] == [0, 1, 2]
+
+        # Verify best model
+        best_result = registry.get_best_model()
+        assert best_result is not None
+        _, best_metadata = best_result
+        assert best_metadata.model_id == "ppo_gen_002"
+        assert best_metadata.training_metrics.kills_deaths_ratio == 3.5
+
+        # Verify comparison
+        assert registry.is_better_than("ppo_gen_001", "ppo_gen_000")
+        assert registry.is_better_than("ppo_gen_002", "ppo_gen_001")
+        assert registry.is_better_than("ppo_gen_002", "ppo_gen_000")
+        assert not registry.is_better_than("ppo_gen_000", "ppo_gen_001")
+
+        # Verify opponent tracking
+        _, gen1_meta = registry.get_model("ppo_gen_001")
+        assert gen1_meta.opponent_model_id == "ppo_gen_000"
+
+        _, gen2_meta = registry.get_model("ppo_gen_002")
+        assert gen2_meta.opponent_model_id == "ppo_gen_001"
+
+    def test_registry_persistence(self, temp_registry_path: Path):
+        """Integration test: verify registry persists across instances."""
+        # Create first registry instance and register a model
+        registry1 = ModelRegistry(temp_registry_path)
+
+        network = ActorCriticNetwork(observation_size=114, action_size=27)
+        metrics = TrainingMetrics(
+            total_episodes=1000,
+            total_timesteps=100000,
+            average_reward=50.0,
+            average_episode_length=500.0,
+            win_rate=0.6,
+            average_kills=2.5,
+            average_deaths=1.5,
+            kills_deaths_ratio=1.67,
+        )
+
+        model_id = registry1.register_model(
+            model=network,
+            generation=0,
+            opponent_model_id=None,
+            training_metrics=metrics,
+            hyperparameters={"learning_rate": 3e-4},
+            training_duration_seconds=3600.0,
+        )
+
+        # Create new registry instance pointing to same path
+        registry2 = ModelRegistry(temp_registry_path)
+
+        # Verify model is accessible from new instance
+        models = registry2.list_models()
+        assert len(models) == 1
+        assert models[0].model_id == model_id
+
+        # Verify can load the model
+        loaded_network, metadata = registry2.get_model(model_id)
+        assert isinstance(loaded_network, ActorCriticNetwork)
+        assert metadata.training_metrics.kills_deaths_ratio == 1.67
+
+    def test_registry_delete_cleanup(self, registry: ModelRegistry):
+        """Integration test: verify delete properly cleans up files and index."""
+        network = ActorCriticNetwork(observation_size=114, action_size=27)
+        metrics = TrainingMetrics(
+            total_episodes=1000,
+            total_timesteps=100000,
+            average_reward=50.0,
+            average_episode_length=500.0,
+            win_rate=0.6,
+            average_kills=2.5,
+            average_deaths=1.5,
+            kills_deaths_ratio=1.67,
+        )
+
+        # Register two models
+        model_id_0 = registry.register_model(
+            model=network,
+            generation=0,
+            opponent_model_id=None,
+            training_metrics=metrics,
+            hyperparameters={},
+            training_duration_seconds=3600.0,
+        )
+
+        model_id_1 = registry.register_model(
+            model=network,
+            generation=1,
+            opponent_model_id=model_id_0,
+            training_metrics=metrics,
+            hyperparameters={},
+            training_duration_seconds=3600.0,
+        )
+
+        # Verify both models exist
+        assert len(registry.list_models()) == 2
+
+        # Delete first model
+        assert registry.delete_model(model_id_0) is True
+
+        # Verify only one model remains
+        models = registry.list_models()
+        assert len(models) == 1
+        assert models[0].model_id == model_id_1
+
+        # Verify files are cleaned up
+        model_dir = registry.registry_path / "models" / model_id_0
+        assert not model_dir.exists()
+
+    def test_checkpoint_data_access(self, registry: ModelRegistry):
+        """Integration test: verify checkpoint data access for training resumption."""
+        network = ActorCriticNetwork(observation_size=114, action_size=27)
+        optimizer = torch.optim.Adam(network.parameters(), lr=3e-4)
+
+        # Do some "training" to update optimizer state
+        obs = torch.randn(32, 114)
+        logits, value = network(obs)
+        loss = logits.mean() + value.mean()
+        loss.backward()
+        optimizer.step()
+
+        metrics = TrainingMetrics(
+            total_episodes=1000,
+            total_timesteps=100000,
+            average_reward=50.0,
+            average_episode_length=500.0,
+            win_rate=0.6,
+            average_kills=2.5,
+            average_deaths=1.5,
+            kills_deaths_ratio=1.67,
+        )
+
+        model_id = registry.register_model(
+            model=network,
+            generation=0,
+            opponent_model_id=None,
+            training_metrics=metrics,
+            hyperparameters={"learning_rate": 3e-4},
+            training_duration_seconds=3600.0,
+            optimizer=optimizer,
+            training_step=100,
+        )
+
+        # Get checkpoint data
+        checkpoint = registry.get_checkpoint_data(model_id)
+
+        assert checkpoint.training_step == 100
+        assert checkpoint.total_timesteps == 100000
+        assert "learning_rate" in checkpoint.hyperparameters
+
+        # Optimizer state should be saved
+        assert checkpoint.optimizer_state_dict is not None
+
+
+class TestMultiGenerationTraining:
+    """Tests simulating the successive training pipeline."""
+
+    def test_full_successive_training_workflow(self, registry: ModelRegistry):
+        """Simulate a complete successive training workflow.
+
+        This test simulates:
+        1. Training gen 0 against a base opponent
+        2. Checking if gen 0 is "better" (K/D > threshold)
+        3. Training gen 1 against gen 0
+        4. Comparing generations and selecting the best
+        """
+        target_kd_ratio = 2.0  # Target K/D ratio to be considered "good"
+
+        # Generation 0: Not good enough yet
+        gen0_network = ActorCriticNetwork(observation_size=114, action_size=27)
+        gen0_metrics = TrainingMetrics(
+            total_episodes=1000,
+            total_timesteps=100000,
+            average_reward=35.0,
+            average_episode_length=350.0,
+            win_rate=0.45,
+            average_kills=1.5,
+            average_deaths=1.8,
+            kills_deaths_ratio=0.83,  # Below threshold
+        )
+
+        gen0_id = registry.register_model(
+            model=gen0_network,
+            generation=0,
+            opponent_model_id=None,
+            training_metrics=gen0_metrics,
+            hyperparameters={"learning_rate": 3e-4},
+            training_duration_seconds=3600.0,
+        )
+
+        # Check if gen0 meets threshold
+        gen0_meta = registry.get_metadata(gen0_id)
+        assert gen0_meta.training_metrics.kills_deaths_ratio < target_kd_ratio
+
+        # Generation 1: Better but not there yet
+        gen1_network = ActorCriticNetwork(observation_size=114, action_size=27)
+        gen1_metrics = TrainingMetrics(
+            total_episodes=2000,
+            total_timesteps=200000,
+            average_reward=55.0,
+            average_episode_length=450.0,
+            win_rate=0.6,
+            average_kills=2.2,
+            average_deaths=1.5,
+            kills_deaths_ratio=1.47,  # Better but still below threshold
+        )
+
+        gen1_id = registry.register_model(
+            model=gen1_network,
+            generation=1,
+            opponent_model_id=gen0_id,
+            training_metrics=gen1_metrics,
+            hyperparameters={"learning_rate": 3e-4},
+            training_duration_seconds=7200.0,
+        )
+
+        # Verify gen1 is better than gen0
+        assert registry.is_better_than(gen1_id, gen0_id)
+
+        # Check if gen1 meets threshold
+        gen1_meta = registry.get_metadata(gen1_id)
+        assert gen1_meta.training_metrics.kills_deaths_ratio < target_kd_ratio
+
+        # Generation 2: Meets the threshold!
+        gen2_network = ActorCriticNetwork(observation_size=114, action_size=27)
+        gen2_metrics = TrainingMetrics(
+            total_episodes=3000,
+            total_timesteps=300000,
+            average_reward=80.0,
+            average_episode_length=600.0,
+            win_rate=0.75,
+            average_kills=3.0,
+            average_deaths=1.2,
+            kills_deaths_ratio=2.5,  # Meets threshold!
+        )
+
+        gen2_id = registry.register_model(
+            model=gen2_network,
+            generation=2,
+            opponent_model_id=gen1_id,
+            training_metrics=gen2_metrics,
+            hyperparameters={"learning_rate": 3e-4},
+            training_duration_seconds=10800.0,
+        )
+
+        # Verify gen2 meets threshold
+        gen2_meta = registry.get_metadata(gen2_id)
+        assert gen2_meta.training_metrics.kills_deaths_ratio >= target_kd_ratio
+
+        # Verify gen2 is the best model
+        best_result = registry.get_best_model()
+        assert best_result is not None
+        _, best_meta = best_result
+        assert best_meta.model_id == gen2_id
+
+        # Verify lineage
+        assert gen2_meta.opponent_model_id == gen1_id
+        assert gen1_meta.opponent_model_id == gen0_id
+        assert gen0_meta.opponent_model_id is None

--- a/bot2/tests/unit/test_serialization.py
+++ b/bot2/tests/unit/test_serialization.py
@@ -9,8 +9,8 @@ import torch
 
 from bot.agent.network import ActorCriticNetwork
 from bot.agent.serialization import (
+    CheckpointMetadata,
     ModelCheckpoint,
-    ModelMetadata,
     generate_model_filename,
     get_checkpoint_info,
     load_model,
@@ -18,12 +18,12 @@ from bot.agent.serialization import (
 )
 
 
-class TestModelMetadata:
-    """Tests for ModelMetadata dataclass."""
+class TestCheckpointMetadata:
+    """Tests for CheckpointMetadata dataclass."""
 
     def test_create_minimal(self):
         """Test creating metadata with minimal required fields."""
-        metadata = ModelMetadata(
+        metadata = CheckpointMetadata(
             version="v1.0.0",
             created_at=datetime.now(timezone.utc),
             observation_size=114,
@@ -40,7 +40,7 @@ class TestModelMetadata:
 
     def test_create_full(self):
         """Test creating metadata with all fields."""
-        metadata = ModelMetadata(
+        metadata = CheckpointMetadata(
             version="gen-005",
             created_at=datetime.now(timezone.utc),
             observation_size=100,
@@ -65,7 +65,7 @@ class TestModelCheckpoint:
 
     def test_create_checkpoint(self):
         """Test creating a model checkpoint."""
-        metadata = ModelMetadata(
+        metadata = CheckpointMetadata(
             version="v1",
             created_at=datetime.now(timezone.utc),
             observation_size=114,

--- a/bot2/tests/unit/training/__init__.py
+++ b/bot2/tests/unit/training/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for training module."""

--- a/bot2/tests/unit/training/registry/__init__.py
+++ b/bot2/tests/unit/training/registry/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for model registry module."""

--- a/bot2/tests/unit/training/registry/test_model_registry.py
+++ b/bot2/tests/unit/training/registry/test_model_registry.py
@@ -1,0 +1,688 @@
+"""Unit tests for the model registry."""
+
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+import torch
+
+from bot.agent.network import ActorCriticNetwork
+from bot.training.registry import (
+    ModelAlreadyExistsError,
+    ModelMetadata,
+    ModelNotFoundError,
+    ModelRegistry,
+    NetworkArchitecture,
+    RegistryIndex,
+    StorageBackend,
+    TrainingMetrics,
+)
+
+# Fixtures
+
+
+@pytest.fixture
+def sample_metrics() -> TrainingMetrics:
+    """Create sample training metrics for testing."""
+    return TrainingMetrics(
+        total_episodes=1000,
+        total_timesteps=100000,
+        average_reward=50.0,
+        average_episode_length=500.0,
+        win_rate=0.6,
+        average_kills=2.5,
+        average_deaths=1.5,
+        kills_deaths_ratio=1.67,
+    )
+
+
+@pytest.fixture
+def sample_hyperparams() -> dict:
+    """Create sample hyperparameters for testing."""
+    return {
+        "learning_rate": 3e-4,
+        "gamma": 0.99,
+        "clip_range": 0.2,
+        "n_epochs": 10,
+    }
+
+
+@pytest.fixture
+def sample_network() -> ActorCriticNetwork:
+    """Create a sample network for testing."""
+    return ActorCriticNetwork(observation_size=114, action_size=27, hidden_size=256)
+
+
+@pytest.fixture
+def temp_registry_path():
+    """Create a temporary directory for registry storage."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir) / "registry"
+
+
+@pytest.fixture
+def registry(temp_registry_path: Path) -> ModelRegistry:
+    """Create a ModelRegistry with temporary storage."""
+    return ModelRegistry(temp_registry_path)
+
+
+# TrainingMetrics Tests
+
+
+class TestTrainingMetrics:
+    """Tests for TrainingMetrics Pydantic model."""
+
+    def test_create_valid_metrics(self, sample_metrics: TrainingMetrics):
+        """Test creating valid training metrics."""
+        assert sample_metrics.total_episodes == 1000
+        assert sample_metrics.total_timesteps == 100000
+        assert sample_metrics.average_reward == 50.0
+        assert sample_metrics.kills_deaths_ratio == 1.67
+
+    def test_metrics_validation_negative_episodes(self):
+        """Test that negative episodes are rejected."""
+        with pytest.raises(ValueError):
+            TrainingMetrics(
+                total_episodes=-1,
+                total_timesteps=100000,
+                average_reward=50.0,
+                average_episode_length=500.0,
+                win_rate=0.6,
+                average_kills=2.5,
+                average_deaths=1.5,
+                kills_deaths_ratio=1.67,
+            )
+
+    def test_metrics_validation_win_rate_range(self):
+        """Test that win_rate must be between 0 and 1."""
+        with pytest.raises(ValueError):
+            TrainingMetrics(
+                total_episodes=100,
+                total_timesteps=10000,
+                average_reward=50.0,
+                average_episode_length=500.0,
+                win_rate=1.5,  # Invalid: > 1.0
+                average_kills=2.5,
+                average_deaths=1.5,
+                kills_deaths_ratio=1.67,
+            )
+
+    def test_metrics_frozen(self, sample_metrics: TrainingMetrics):
+        """Test that metrics are immutable."""
+        with pytest.raises(Exception):  # Pydantic frozen model raises ValidationError
+            sample_metrics.total_episodes = 999
+
+
+class TestNetworkArchitecture:
+    """Tests for NetworkArchitecture Pydantic model."""
+
+    def test_create_valid_architecture(self):
+        """Test creating valid network architecture."""
+        arch = NetworkArchitecture(
+            observation_size=114,
+            action_size=27,
+            hidden_size=256,
+            actor_hidden=128,
+            critic_hidden=128,
+        )
+        assert arch.observation_size == 114
+        assert arch.action_size == 27
+
+    def test_architecture_validation_positive_values(self):
+        """Test that dimensions must be positive."""
+        with pytest.raises(ValueError):
+            NetworkArchitecture(
+                observation_size=0,  # Invalid: must be > 0
+                action_size=27,
+            )
+
+
+class TestModelMetadata:
+    """Tests for ModelMetadata Pydantic model."""
+
+    def test_create_full_metadata(self, sample_metrics: TrainingMetrics):
+        """Test creating full model metadata."""
+        arch = NetworkArchitecture(
+            observation_size=114, action_size=27, hidden_size=256
+        )
+        metadata = ModelMetadata(
+            model_id="ppo_gen_000",
+            generation=0,
+            created_at=datetime.now(timezone.utc),
+            training_duration_seconds=3600.0,
+            opponent_model_id=None,
+            training_metrics=sample_metrics,
+            hyperparameters={"learning_rate": 3e-4},
+            architecture=arch,
+            checkpoint_path="models/ppo_gen_000/model.pt",
+            notes="First generation model",
+        )
+        assert metadata.model_id == "ppo_gen_000"
+        assert metadata.generation == 0
+        assert metadata.opponent_model_id is None
+        assert metadata.notes == "First generation model"
+
+    def test_metadata_serialization(self, sample_metrics: TrainingMetrics):
+        """Test metadata serialization to dict."""
+        arch = NetworkArchitecture(observation_size=114, action_size=27)
+        metadata = ModelMetadata(
+            model_id="ppo_gen_001",
+            generation=1,
+            created_at=datetime.now(timezone.utc),
+            training_duration_seconds=7200.0,
+            opponent_model_id="ppo_gen_000",
+            training_metrics=sample_metrics,
+            hyperparameters={},
+            architecture=arch,
+            checkpoint_path="models/ppo_gen_001/model.pt",
+        )
+
+        data = metadata.model_dump(mode="json")
+        assert data["model_id"] == "ppo_gen_001"
+        assert data["generation"] == 1
+        assert isinstance(data["created_at"], str)  # ISO format string
+
+        # Round-trip test
+        restored = ModelMetadata.model_validate(data)
+        assert restored.model_id == metadata.model_id
+        assert (
+            restored.training_metrics.kills_deaths_ratio
+            == sample_metrics.kills_deaths_ratio
+        )
+
+
+# StorageBackend Tests
+
+
+class TestStorageBackend:
+    """Tests for StorageBackend class."""
+
+    def test_initialize_creates_directories(self, temp_registry_path: Path):
+        """Test that initialize creates required directories."""
+        backend = StorageBackend(temp_registry_path)
+        backend.initialize()
+
+        assert temp_registry_path.exists()
+        assert (temp_registry_path / "models").exists()
+        assert (temp_registry_path / "index.json").exists()
+
+    def test_model_exists_false_for_new_model(self, temp_registry_path: Path):
+        """Test model_exists returns False for non-existent model."""
+        backend = StorageBackend(temp_registry_path)
+        backend.initialize()
+
+        assert not backend.model_exists("ppo_gen_000")
+
+    def test_get_next_generation_empty_registry(self, temp_registry_path: Path):
+        """Test next generation is 0 for empty registry."""
+        backend = StorageBackend(temp_registry_path)
+        backend.initialize()
+
+        assert backend.get_next_generation() == 0
+
+
+class TestRegistryIndex:
+    """Tests for RegistryIndex class."""
+
+    def test_create_empty_index(self):
+        """Test creating empty registry index."""
+        index = RegistryIndex()
+        assert len(index.models) == 0
+        assert index.last_updated is not None
+
+    def test_index_serialization_roundtrip(self, sample_metrics: TrainingMetrics):
+        """Test index serialization and deserialization."""
+        arch = NetworkArchitecture(observation_size=114, action_size=27)
+        metadata = ModelMetadata(
+            model_id="ppo_gen_000",
+            generation=0,
+            created_at=datetime.now(timezone.utc),
+            training_duration_seconds=3600.0,
+            training_metrics=sample_metrics,
+            hyperparameters={},
+            architecture=arch,
+            checkpoint_path="models/ppo_gen_000/model.pt",
+        )
+
+        index = RegistryIndex(models={"ppo_gen_000": metadata})
+        data = index.to_dict()
+
+        restored = RegistryIndex.from_dict(data)
+        assert "ppo_gen_000" in restored.models
+        assert restored.models["ppo_gen_000"].generation == 0
+
+
+# ModelRegistry Tests
+
+
+class TestModelRegistry:
+    """Tests for ModelRegistry class."""
+
+    def test_registry_initialization(self, registry: ModelRegistry):
+        """Test registry initializes correctly."""
+        assert registry.registry_path.exists()
+
+    def test_register_model(
+        self,
+        registry: ModelRegistry,
+        sample_network: ActorCriticNetwork,
+        sample_metrics: TrainingMetrics,
+        sample_hyperparams: dict,
+    ):
+        """Test registering a new model."""
+        model_id = registry.register_model(
+            model=sample_network,
+            generation=0,
+            opponent_model_id=None,
+            training_metrics=sample_metrics,
+            hyperparameters=sample_hyperparams,
+            training_duration_seconds=3600.0,
+        )
+
+        assert model_id == "ppo_gen_000"
+
+        # Verify model files exist
+        checkpoint_path = registry.registry_path / "models" / "ppo_gen_000" / "model.pt"
+        metadata_path = (
+            registry.registry_path / "models" / "ppo_gen_000" / "metadata.json"
+        )
+        assert checkpoint_path.exists()
+        assert metadata_path.exists()
+
+    def test_register_model_duplicate_raises_error(
+        self,
+        registry: ModelRegistry,
+        sample_network: ActorCriticNetwork,
+        sample_metrics: TrainingMetrics,
+        sample_hyperparams: dict,
+    ):
+        """Test registering duplicate model raises error."""
+        registry.register_model(
+            model=sample_network,
+            generation=0,
+            opponent_model_id=None,
+            training_metrics=sample_metrics,
+            hyperparameters=sample_hyperparams,
+            training_duration_seconds=3600.0,
+        )
+
+        with pytest.raises(ModelAlreadyExistsError):
+            registry.register_model(
+                model=sample_network,
+                generation=0,  # Same generation
+                opponent_model_id=None,
+                training_metrics=sample_metrics,
+                hyperparameters=sample_hyperparams,
+                training_duration_seconds=3600.0,
+            )
+
+    def test_get_model(
+        self,
+        registry: ModelRegistry,
+        sample_network: ActorCriticNetwork,
+        sample_metrics: TrainingMetrics,
+        sample_hyperparams: dict,
+    ):
+        """Test retrieving a registered model."""
+        model_id = registry.register_model(
+            model=sample_network,
+            generation=0,
+            opponent_model_id=None,
+            training_metrics=sample_metrics,
+            hyperparameters=sample_hyperparams,
+            training_duration_seconds=3600.0,
+        )
+
+        network, metadata = registry.get_model(model_id)
+
+        assert isinstance(network, ActorCriticNetwork)
+        assert metadata.model_id == "ppo_gen_000"
+        assert metadata.generation == 0
+        assert metadata.training_metrics.total_episodes == sample_metrics.total_episodes
+
+    def test_get_model_not_found(self, registry: ModelRegistry):
+        """Test getting non-existent model raises error."""
+        with pytest.raises(ModelNotFoundError):
+            registry.get_model("nonexistent_model")
+
+    def test_get_model_by_generation(
+        self,
+        registry: ModelRegistry,
+        sample_network: ActorCriticNetwork,
+        sample_metrics: TrainingMetrics,
+        sample_hyperparams: dict,
+    ):
+        """Test retrieving model by generation number."""
+        registry.register_model(
+            model=sample_network,
+            generation=0,
+            opponent_model_id=None,
+            training_metrics=sample_metrics,
+            hyperparameters=sample_hyperparams,
+            training_duration_seconds=3600.0,
+        )
+
+        result = registry.get_model_by_generation(0)
+        assert result is not None
+        network, metadata = result
+        assert metadata.generation == 0
+
+        # Non-existent generation returns None
+        assert registry.get_model_by_generation(1) is None
+
+    def test_get_latest_model(
+        self,
+        registry: ModelRegistry,
+        sample_network: ActorCriticNetwork,
+        sample_metrics: TrainingMetrics,
+        sample_hyperparams: dict,
+    ):
+        """Test getting the latest model."""
+        # Register two models
+        registry.register_model(
+            model=sample_network,
+            generation=0,
+            opponent_model_id=None,
+            training_metrics=sample_metrics,
+            hyperparameters=sample_hyperparams,
+            training_duration_seconds=3600.0,
+        )
+
+        better_metrics = TrainingMetrics(
+            total_episodes=2000,
+            total_timesteps=200000,
+            average_reward=75.0,
+            average_episode_length=600.0,
+            win_rate=0.8,
+            average_kills=3.0,
+            average_deaths=1.0,
+            kills_deaths_ratio=3.0,
+        )
+        registry.register_model(
+            model=sample_network,
+            generation=1,
+            opponent_model_id="ppo_gen_000",
+            training_metrics=better_metrics,
+            hyperparameters=sample_hyperparams,
+            training_duration_seconds=7200.0,
+        )
+
+        result = registry.get_latest_model()
+        assert result is not None
+        _, metadata = result
+        assert metadata.generation == 1
+
+    def test_get_latest_model_empty_registry(self, registry: ModelRegistry):
+        """Test getting latest model from empty registry returns None."""
+        assert registry.get_latest_model() is None
+
+    def test_list_models(
+        self,
+        registry: ModelRegistry,
+        sample_network: ActorCriticNetwork,
+        sample_metrics: TrainingMetrics,
+        sample_hyperparams: dict,
+    ):
+        """Test listing all models."""
+        # Register two models
+        registry.register_model(
+            model=sample_network,
+            generation=0,
+            opponent_model_id=None,
+            training_metrics=sample_metrics,
+            hyperparameters=sample_hyperparams,
+            training_duration_seconds=3600.0,
+        )
+        registry.register_model(
+            model=sample_network,
+            generation=1,
+            opponent_model_id="ppo_gen_000",
+            training_metrics=sample_metrics,
+            hyperparameters=sample_hyperparams,
+            training_duration_seconds=7200.0,
+        )
+
+        models = registry.list_models()
+        assert len(models) == 2
+        assert models[0].generation == 0  # Sorted by generation
+        assert models[1].generation == 1
+
+    def test_get_best_model(
+        self,
+        registry: ModelRegistry,
+        sample_network: ActorCriticNetwork,
+        sample_hyperparams: dict,
+    ):
+        """Test getting the best model by K/D ratio."""
+        weak_metrics = TrainingMetrics(
+            total_episodes=1000,
+            total_timesteps=100000,
+            average_reward=30.0,
+            average_episode_length=400.0,
+            win_rate=0.4,
+            average_kills=1.0,
+            average_deaths=2.0,
+            kills_deaths_ratio=0.5,
+        )
+        registry.register_model(
+            model=sample_network,
+            generation=0,
+            opponent_model_id=None,
+            training_metrics=weak_metrics,
+            hyperparameters=sample_hyperparams,
+            training_duration_seconds=3600.0,
+        )
+
+        strong_metrics = TrainingMetrics(
+            total_episodes=2000,
+            total_timesteps=200000,
+            average_reward=80.0,
+            average_episode_length=600.0,
+            win_rate=0.9,
+            average_kills=4.0,
+            average_deaths=1.0,
+            kills_deaths_ratio=4.0,
+        )
+        registry.register_model(
+            model=sample_network,
+            generation=1,
+            opponent_model_id="ppo_gen_000",
+            training_metrics=strong_metrics,
+            hyperparameters=sample_hyperparams,
+            training_duration_seconds=7200.0,
+        )
+
+        result = registry.get_best_model()
+        assert result is not None
+        _, metadata = result
+        assert metadata.model_id == "ppo_gen_001"
+        assert metadata.training_metrics.kills_deaths_ratio == 4.0
+
+    def test_is_better_than(
+        self,
+        registry: ModelRegistry,
+        sample_network: ActorCriticNetwork,
+        sample_hyperparams: dict,
+    ):
+        """Test comparing two models."""
+        weak_metrics = TrainingMetrics(
+            total_episodes=1000,
+            total_timesteps=100000,
+            average_reward=30.0,
+            average_episode_length=400.0,
+            win_rate=0.4,
+            average_kills=1.0,
+            average_deaths=2.0,
+            kills_deaths_ratio=0.5,
+        )
+        registry.register_model(
+            model=sample_network,
+            generation=0,
+            opponent_model_id=None,
+            training_metrics=weak_metrics,
+            hyperparameters=sample_hyperparams,
+            training_duration_seconds=3600.0,
+        )
+
+        strong_metrics = TrainingMetrics(
+            total_episodes=2000,
+            total_timesteps=200000,
+            average_reward=80.0,
+            average_episode_length=600.0,
+            win_rate=0.9,
+            average_kills=4.0,
+            average_deaths=1.0,
+            kills_deaths_ratio=4.0,
+        )
+        registry.register_model(
+            model=sample_network,
+            generation=1,
+            opponent_model_id="ppo_gen_000",
+            training_metrics=strong_metrics,
+            hyperparameters=sample_hyperparams,
+            training_duration_seconds=7200.0,
+        )
+
+        assert registry.is_better_than("ppo_gen_001", "ppo_gen_000") is True
+        assert registry.is_better_than("ppo_gen_000", "ppo_gen_001") is False
+
+    def test_is_better_than_model_not_found(
+        self,
+        registry: ModelRegistry,
+        sample_network: ActorCriticNetwork,
+        sample_metrics: TrainingMetrics,
+        sample_hyperparams: dict,
+    ):
+        """Test is_better_than raises error for non-existent model."""
+        registry.register_model(
+            model=sample_network,
+            generation=0,
+            opponent_model_id=None,
+            training_metrics=sample_metrics,
+            hyperparameters=sample_hyperparams,
+            training_duration_seconds=3600.0,
+        )
+
+        with pytest.raises(ModelNotFoundError):
+            registry.is_better_than("ppo_gen_000", "nonexistent")
+
+    def test_delete_model(
+        self,
+        registry: ModelRegistry,
+        sample_network: ActorCriticNetwork,
+        sample_metrics: TrainingMetrics,
+        sample_hyperparams: dict,
+    ):
+        """Test deleting a model."""
+        model_id = registry.register_model(
+            model=sample_network,
+            generation=0,
+            opponent_model_id=None,
+            training_metrics=sample_metrics,
+            hyperparameters=sample_hyperparams,
+            training_duration_seconds=3600.0,
+        )
+
+        assert registry.delete_model(model_id) is True
+
+        # Verify model is gone
+        with pytest.raises(ModelNotFoundError):
+            registry.get_model(model_id)
+
+        # Delete non-existent model returns False
+        assert registry.delete_model("nonexistent") is False
+
+    def test_get_next_generation(
+        self,
+        registry: ModelRegistry,
+        sample_network: ActorCriticNetwork,
+        sample_metrics: TrainingMetrics,
+        sample_hyperparams: dict,
+    ):
+        """Test getting the next generation number."""
+        assert registry.get_next_generation() == 0
+
+        registry.register_model(
+            model=sample_network,
+            generation=0,
+            opponent_model_id=None,
+            training_metrics=sample_metrics,
+            hyperparameters=sample_hyperparams,
+            training_duration_seconds=3600.0,
+        )
+
+        assert registry.get_next_generation() == 1
+
+        registry.register_model(
+            model=sample_network,
+            generation=1,
+            opponent_model_id="ppo_gen_000",
+            training_metrics=sample_metrics,
+            hyperparameters=sample_hyperparams,
+            training_duration_seconds=7200.0,
+        )
+
+        assert registry.get_next_generation() == 2
+
+    def test_get_metadata_without_loading_weights(
+        self,
+        registry: ModelRegistry,
+        sample_network: ActorCriticNetwork,
+        sample_metrics: TrainingMetrics,
+        sample_hyperparams: dict,
+    ):
+        """Test getting metadata without loading full model."""
+        registry.register_model(
+            model=sample_network,
+            generation=0,
+            opponent_model_id=None,
+            training_metrics=sample_metrics,
+            hyperparameters=sample_hyperparams,
+            training_duration_seconds=3600.0,
+            notes="Test model",
+        )
+
+        metadata = registry.get_metadata("ppo_gen_000")
+        assert metadata.model_id == "ppo_gen_000"
+        assert metadata.notes == "Test model"
+
+    def test_model_weights_preservation(
+        self,
+        registry: ModelRegistry,
+        sample_network: ActorCriticNetwork,
+        sample_metrics: TrainingMetrics,
+        sample_hyperparams: dict,
+    ):
+        """Test that model weights are preserved after registration."""
+        # Run input through original network
+        obs = torch.randn(1, sample_network.observation_size)
+        original_logits, original_value = sample_network(obs)
+
+        model_id = registry.register_model(
+            model=sample_network,
+            generation=0,
+            opponent_model_id=None,
+            training_metrics=sample_metrics,
+            hyperparameters=sample_hyperparams,
+            training_duration_seconds=3600.0,
+        )
+
+        # Load and compare
+        loaded_network, _ = registry.get_model(model_id)
+        loaded_logits, loaded_value = loaded_network(obs)
+
+        assert torch.allclose(original_logits, loaded_logits)
+        assert torch.allclose(original_value, loaded_value)
+
+
+class TestModelIdGeneration:
+    """Tests for model ID generation."""
+
+    def test_model_id_format(self, registry: ModelRegistry):
+        """Test model ID format."""
+        assert registry._generate_model_id(0) == "ppo_gen_000"
+        assert registry._generate_model_id(1) == "ppo_gen_001"
+        assert registry._generate_model_id(10) == "ppo_gen_010"
+        assert registry._generate_model_id(100) == "ppo_gen_100"
+        assert registry._generate_model_id(999) == "ppo_gen_999"


### PR DESCRIPTION
**Closes:** #46

## Summary

This PR implements a model registry component for storing, versioning, and retrieving trained PPO models with associated metadata. The registry is essential for the successive training pipeline where new ML models train against previous generations until they surpass a performance threshold (average kills/deaths ratio).

### Key Features

- **Model versioning** with generation-based naming (`ppo_gen_000`, `ppo_gen_001`, etc.)
- **Comprehensive metadata tracking** including training metrics, hyperparameters, network architecture, and opponent lineage
- **Performance comparison** using kills/deaths ratio as the primary metric
- **Thread-safe operations** with file locking for concurrent access
- **Fast metadata queries** via index.json without loading model weights
- **Full checkpoint support** for training resumption with optimizer state

## Changes

### New Files

| File | Description |
|------|-------------|
| [model_metadata.py](bot2/src/bot/training/registry/model_metadata.py) | Pydantic models for `TrainingMetrics`, `NetworkArchitecture`, and `ModelMetadata` |
| [model_registry.py](bot2/src/bot/training/registry/model_registry.py) | Main `ModelRegistry` class with register, get, list, compare, and delete operations |
| [storage_backend.py](bot2/src/bot/training/registry/storage_backend.py) | File-based storage with `RegistryIndex` for fast queries and `StorageBackend` for persistence |
| [registry/__init__.py](bot2/src/bot/training/registry/__init__.py) | Module exports for registry components |
| [test_model_registry.py](bot2/tests/unit/training/registry/test_model_registry.py) | Unit tests covering metadata validation, storage backend, and registry operations |
| [test_registry_integration.py](bot2/tests/integration/training/test_registry_integration.py) | Integration tests for complete workflows including successive training simulation |

### Modified Files

| File | Description |
|------|-------------|
| [bot2/src/bot/agent/__init__.py](bot2/src/bot/agent/__init__.py) | Updated exports |
| [bot2/src/bot/agent/serialization.py](bot2/src/bot/agent/serialization.py) | Minor updates to support registry integration |
| [bot2/src/bot/training/__init__.py](bot2/src/bot/training/__init__.py) | Added registry exports |
| [bot2/tests/unit/test_serialization.py](bot2/tests/unit/test_serialization.py) | Test updates for serialization changes |

## API Overview

### ModelRegistry

```python
registry = ModelRegistry("/path/to/registry")

# Register a new model
model_id = registry.register_model(
    model=trained_network,
    generation=0,
    opponent_model_id=None,
    training_metrics=metrics,
    hyperparameters=config,
    training_duration_seconds=3600.0,
)

# Retrieve models
network, metadata = registry.get_model(model_id)
network, metadata = registry.get_model_by_generation(0)
network, metadata = registry.get_latest_model()
network, metadata = registry.get_best_model()

# Compare models
is_better = registry.is_better_than("ppo_gen_001", "ppo_gen_000")

# List and query
all_models = registry.list_models()
next_gen = registry.get_next_generation()
metadata = registry.get_metadata(model_id)
```

### Storage Structure

```
registry/
├── index.json           # Model index with all metadata
├── index.json.lock      # Lock file for concurrent access
└── models/
    ├── ppo_gen_000/
    │   ├── model.pt     # PyTorch checkpoint
    │   └── metadata.json
    ├── ppo_gen_001/
    │   ├── model.pt
    │   └── metadata.json
    └── ...
```

## Test Plan

- [x] Unit tests for `TrainingMetrics` validation (positive values, win_rate range, frozen model)
- [x] Unit tests for `NetworkArchitecture` validation
- [x] Unit tests for `ModelMetadata` serialization/deserialization
- [x] Unit tests for `StorageBackend` (directory creation, model existence, next generation)
- [x] Unit tests for `RegistryIndex` serialization roundtrip
- [x] Unit tests for `ModelRegistry` operations (register, get, list, compare, delete)
- [x] Unit tests for model ID generation format
- [x] Unit tests for model weights preservation after registration
- [x] Integration test: register -> retrieve -> verify weights match
- [x] Integration test: successive model registration across 3 generations
- [x] Integration test: registry persistence across instances
- [x] Integration test: delete cleanup of files and index
- [x] Integration test: checkpoint data access for training resumption
- [x] Integration test: full successive training workflow simulation

## Integration Points

This registry integrates with the existing codebase:

- Uses `ActorCriticNetwork` from `bot.agent.network`
- Uses `save_model`/`load_model` from `bot.agent.serialization`
- Designed for use by Training Orchestrator (TASK-027), Successive Training Logic (TASK-028), and Generation Dashboard (TASK-032)
