### PR TITLE
Add Bot Service Taskfile Commands

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -106,6 +106,22 @@ tasks:
       - bot2:format
       - bot2:typecheck
 
+  bot2:service:
+    dir: bot2
+    desc: Run the Bot Service
+    cmds:
+      - uv run python -m bot.service
+    deps:
+      - bot2:install
+
+  bot2:service:dev:
+    dir: bot2
+    desc: Run the Bot Service with auto-reload for development
+    cmds:
+      - uv run uvicorn bot.service.bot_service:app --reload --host 0.0.0.0 --port 8080
+    deps:
+      - bot2:install
+
   #
   # backend (golang) tasks
   #


### PR DESCRIPTION
Closes #101

## Summary
Adds Taskfile commands for running the Bot Service, completing the infrastructure setup for the "Add Bots to End-User Games" feature. This enables developers to easily start the service in both production and development modes.

## Changes Made

### Taskfile.yml
- Added `bot2:service` task to run the Bot Service via `uv run python -m bot.service`
- Added `bot2:service:dev` task with auto-reload for development using uvicorn's `--reload` flag
- Both tasks include `bot2:install` as a dependency to ensure packages are installed

## Testing
- Verify with `task bot2:service` - service starts on default port 8080
- Verify with `task bot2:service:dev` - service starts with hot-reload enabled
- Health check: `curl http://localhost:8080/health` returns `{"status": "healthy"}`

## Additional Notes
- Dependencies (`fastapi>=0.115.0`, `uvicorn>=0.34.0`) were already added to `bot2/pyproject.toml` in a previous PR
- This is the final task in the "Add Bots to End-User Games" epic (#95)
- Service respects environment variables: `BOT_SERVICE_PORT`, `BOT_SERVICE_HOST`, `GAME_SERVER_HTTP_URL`, `GAME_SERVER_WS_URL`
